### PR TITLE
Calculate new run date based on old run date not on current time

### DIFF
--- a/lib/scheduled_tasks_checker.rb
+++ b/lib/scheduled_tasks_checker.rb
@@ -20,7 +20,8 @@ class ScheduledTasksChecker
       issue.save
       interval = task.interval_number
       units = task.interval_units
-      task.next_run_date =  interval.send(units.downcase).from_now
+      interval_steps = ((Time.now - task.next_run_date) / interval.send(units.downcase)).ceil
+      task.next_run_date += (interval * interval_steps).send(units.downcase)
       task.save
     end
   end


### PR DESCRIPTION
This should fix Issue #10. Instead of setting next_run_date based on current time it is calculated based on interval and current time.
