### PR TITLE
spelling fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You should have a project named *project1* with `periodictask` installed
 Authors
 -------
 
-  - [Julian Perelli](https://jperelli.com.ar/) (Current Mantainer)
+  - [Julian Perelli](https://jperelli.com.ar/) (Current Maintainer)
   - [Tanguy de Courson](https://github.com/myneid/) (Original Author)
 
 License


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.

really like that plugin. thanks for your efforts here !