### PR TITLE
Bang added to issue.save!

### DIFF
--- a/lib/scheduled_tasks_checker.rb
+++ b/lib/scheduled_tasks_checker.rb
@@ -31,7 +31,7 @@ class ScheduledTasksChecker
         due_date_units = task.due_date_units
         issue.due_date = due_date.send(due_date_units.downcase).from_now
       end
-      issue.save
+      issue.save!
       interval = task.interval_number
       units = task.interval_units
 


### PR DESCRIPTION
After adding the bang to `issue.save!` I am able to troubleshoot errors on issues creation.
I have added a mandatory custom fields to issues and `redmine:check_periodictasks` was not able to create a new issue. The task was ending without errors becouse of the missing bang.