### PR TITLE
Custom fields and other fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-gem 'business_time', '0.7.6'
+gem 'business_time', '>= 0.7.6'

--- a/app/models/periodictask.rb
+++ b/app/models/periodictask.rb
@@ -3,8 +3,11 @@ class Periodictask < ActiveRecord::Base
   belongs_to :project
   belongs_to :assigned_to, :class_name => 'Principal', :foreign_key => 'assigned_to_id'
   belongs_to :issue_category, :class_name => 'IssueCategory', :foreign_key => 'issue_category_id'
+  serialize :custom_field_values
   # adapted to changes concerning mass-assigning values to attributes
-  attr_accessible *column_names
+  #attr_accessible *column_names
+  # the above (attr_accessible *column_names) does not work for some reason
+  attr_protected
   INTERVAL_UNITS = [
     [l(:label_unit_day), 'day'],
     [l(:label_unit_business_day), 'business_day'],
@@ -12,4 +15,41 @@ class Periodictask < ActiveRecord::Base
     [l(:label_unit_month), 'month'],
     [l(:label_unit_year), 'year']
   ]
+
+  def generate_issue(now = Time.now)
+    # Copy subject and description and replace variables
+    subj = subject.dup rescue nil
+    if subj.present?
+      subj.gsub!('**DAY**', now.strftime("%d"))
+      subj.gsub!('**WEEK**', now.strftime("%W"))
+      subj.gsub!('**MONTH**', now.strftime("%m"))
+      subj.gsub!('**MONTHNAME**', I18n.localize(now, :format => "%B"))
+      subj.gsub!('**YEAR**', now.strftime("%Y"))
+      subj.gsub!('**PREVIOUS_MONTHNAME**', I18n.localize(now - 2592000, :format => "%B"))
+      subj.gsub!('**PREVIOUS_MONTH**', I18n.localize(now - 2592000, :format => "%m"))
+    end
+    desc = description.dup rescue nil
+    if desc.present?
+      desc.gsub!('**DAY**', now.strftime("%d"))
+      desc.gsub!('**WEEK**', now.strftime("%W"))
+      desc.gsub!('**MONTH**', now.strftime("%m"))
+      desc.gsub!('**MONTHNAME**', I18n.localize(now, :format => "%B"))
+      desc.gsub!('**YEAR**', now.strftime("%Y"))
+      desc.gsub!('**PREVIOUS_MONTHNAME**', I18n.localize(now - 2592000, :format => "%B"))
+      desc.gsub!('**PREVIOUS_MONTH**', I18n.localize(now - 2592000, :format => "%m"))
+    end
+
+    issue = Issue.new(:project_id => project_id, :tracker_id => tracker_id || project.trackers.first.try(:id), :category_id => issue_category_id,
+                      :assigned_to_id => assigned_to_id, :author_id => author_id,
+                      :subject => subj, :description => desc)
+    issue.start_date ||= Date.today if set_start_date?
+    if due_date_number
+      due_date = due_date_number
+      due_date_units = due_date_units || 'day'
+      issue.due_date = due_date.send(due_date_units.downcase).from_now
+    end
+    issue.custom_field_values = custom_field_values if custom_field_values.is_a?(Hash)
+
+    issue
+  end
 end

--- a/app/views/periodictask/_customfields.html.erb
+++ b/app/views/periodictask/_customfields.html.erb
@@ -1,0 +1,8 @@
+<% if @issue.editable_custom_field_values.any? %>
+<fieldset class="box tabular">
+<legend><%= l(:label_issue_custom_fields) %></legend>
+<% issue.editable_custom_field_values.each do |value| %>
+  <p><%= custom_field_tag_with_label(:periodictask, value, :required => issue.required_attribute?(value.custom_field_id)) %></p>
+<% end %>
+</fieldset>
+<% end %>

--- a/app/views/periodictask/_form.html.erb
+++ b/app/views/periodictask/_form.html.erb
@@ -1,4 +1,4 @@
-<%= error_messages_for 'periodictask' %>
+<%= error_messages_for 'periodictask', 'issue' %>
 <%= f.hidden_field :id %>
 <%= f.hidden_field :project_id %>
 <div class="box tabular">
@@ -41,3 +41,19 @@
 <p><%= label(:periodictask, :next_run_date, l(:label_next_run_date)) %><%= f.text_field :next_run_date %> </p>
 <p><%= label(:periodictask, :description, l(:label_description)) %><%= f.text_area :description, :cols => 100, :rows => 10, :no_label => true %></p>
 </div>
+
+<div id="issue_custom_fields">
+<%= render :partial => 'customfields', :locals => { :issue => @issue } %>
+</div>
+
+<%= javascript_tag do %>
+  $(document).ready(function() {
+    $('#periodictask_tracker_id').change(function() {
+      $.ajax({
+        url: '<%= escape_javascript(periodictask_customfields_path(@project, :format => 'js')) %>',
+        type: 'post',
+        data: $(this).closest('form').serialize()
+      });
+    });
+  });
+<% end %>

--- a/app/views/periodictask/_form.html.erb
+++ b/app/views/periodictask/_form.html.erb
@@ -2,6 +2,12 @@
 <%= f.hidden_field :id %>
 <%= f.hidden_field :project_id %>
 <div class="box tabular">
+<% if @periodictask.last_error.present? %>
+<p>
+  <%= label_tag(nil, l(:label_last_error)) %>
+  <%= content_tag('span', @periodictask.last_error, :class => 'icon icon-error') %>
+</p>
+<% end %>
 <p><%= label(:periodictask, :subject, l(:label_subject)) %><%= f.text_field :subject, :required => true, :size => 60 %></p>
 <p><%= l(:subject_variables) %></p>
 <p>

--- a/app/views/periodictask/customfields.js.erb
+++ b/app/views/periodictask/customfields.js.erb
@@ -1,0 +1,1 @@
+$('#issue_custom_fields').html('<%= escape_javascript(render :partial => 'customfields', :locals => { :issue => @issue }) %>');

--- a/app/views/periodictask/index.html.erb
+++ b/app/views/periodictask/index.html.erb
@@ -17,7 +17,10 @@
   <tbody>
     <% @tasks.each do |a| %>
     <tr class="<%= cycle('odd', 'even') %>">
-      <td><%= a.subject %></td>
+      <td>
+        <%= content_tag('span', '', :title => a.last_error, :class => 'icon-only icon-error') if a.last_error.present? %>
+        <%= a.subject %>
+      </td>
       <td><%= a.issue_category%></td>
       <td><%= a.next_run_date %></td>
       <td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,4 @@ en:
   flash_task_saved: Periodic Task is saved
   subject_variables: Possible variables are **DAY** (01-31), **WEEK** (01-53), **MONTH** (01-12), **MONTHNAME** and **PREVIOUS_MONTHNAME** (January - December), **YEAR** (YYYY)
   label_last_error: Last error
+  label_issue_custom_fields: Issue custom fields

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,3 +30,4 @@ en:
   flash_task_created: Periodic Task is created
   flash_task_saved: Periodic Task is saved
   subject_variables: Possible variables are **DAY** (01-31), **WEEK** (01-53), **MONTH** (01-12), **MONTHNAME** and **PREVIOUS_MONTHNAME** (January - December), **YEAR** (YYYY)
+  label_last_error: Last error

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 #  replaced put with match for action 'update', allowing both http-verb options 'put' 
 #  and the new verb 'patch' for compatibility with Redmine 3 and below
   
+  match    'projects/:project_id/periodictask/customfields', :to => 'periodictask#customfields', :as => 'periodictask_customfields', :via => [:post, :patch]
   get      'projects/:project_id/periodictask',            :to => 'periodictask#index',  :as => 'periodictasks'
   get      'projects/:project_id/periodictask/new',        :to => 'periodictask#new',    :as => 'new_periodictask'
   post     'projects/:project_id/periodictask',            :to => 'periodictask#create'

--- a/db/migrate/20180615161616_add_last_error_to_periodictasks.rb
+++ b/db/migrate/20180615161616_add_last_error_to_periodictasks.rb
@@ -1,0 +1,9 @@
+class AddLastErrorToPeriodictasks < ActiveRecord::Migration
+  def self.up
+    add_column :periodictasks, :last_error, :string
+  end
+
+  def self.down
+    remove_column :periodictasks, :last_error
+  end
+end

--- a/db/migrate/20180622232727_add_custom_field_values_to_periodictasks.rb
+++ b/db/migrate/20180622232727_add_custom_field_values_to_periodictasks.rb
@@ -1,0 +1,9 @@
+class AddCustomFieldValuesToPeriodictasks < ActiveRecord::Migration
+  def self.up
+    add_column :periodictasks, :custom_field_values, :text
+  end
+
+  def self.down
+    remove_column :periodictasks, :custom_field_values
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,11 @@
 require 'redmine'
 
+Rails.configuration.to_prepare do
+  unless Project.included_modules.include? RedminePeriodictask::ProjectPatch
+    Project.send(:include, RedminePeriodictask::ProjectPatch)
+  end
+end
+
 Redmine::Plugin.register :periodictask do
   name 'Redmine Periodictask plugin'
   author 'Julian Perelli based on work from Tanguy de Courson'

--- a/lib/redmine_periodictask/project_patch.rb
+++ b/lib/redmine_periodictask/project_patch.rb
@@ -1,0 +1,9 @@
+module RedminePeriodictask
+  module ProjectPatch
+    def self.included(base)
+      base.class_eval do
+        has_many :periodictasks, :dependent => :destroy
+      end
+    end
+  end
+end

--- a/lib/scheduled_tasks_checker.rb
+++ b/lib/scheduled_tasks_checker.rb
@@ -6,31 +6,7 @@ class ScheduledTasksChecker
       # replace variables (set locale from shell)
       I18n.locale = ENV['LOCALE'] || I18n.default_locale
 
-      # Copy subject and description and replace variables
-      subject = task.subject.dup
-      description = task.description.dup
-      subject.gsub!('**DAY**', now.strftime("%d"))
-      subject.gsub!('**WEEK**', now.strftime("%W"))
-      subject.gsub!('**MONTH**', now.strftime("%m"))
-      subject.gsub!('**MONTHNAME**', I18n.localize(now, :format => "%B"))
-      subject.gsub!('**YEAR**', now.strftime("%Y"))
-      subject.gsub!('**PREVIOUS_MONTHNAME**', I18n.localize(now - 2592000, :format => "%B"))
-      subject.gsub!('**PREVIOUS_MONTH**', I18n.localize(now - 2592000, :format => "%m"))
-      description.gsub!('**DAY**', now.strftime("%d"))
-      description.gsub!('**WEEK**', now.strftime("%W"))
-      description.gsub!('**MONTH**', now.strftime("%m"))
-      description.gsub!('**MONTHNAME**', I18n.localize(now, :format => "%B"))
-      description.gsub!('**YEAR**', now.strftime("%Y"))
-      description.gsub!('**PREVIOUS_MONTHNAME**', I18n.localize(now - 2592000, :format => "%B"))
-      description.gsub!('**PREVIOUS_MONTH**', I18n.localize(now - 2592000, :format => "%m"))
-
-      issue = Issue.new(:project_id=>task.project_id,  :tracker_id=>task.tracker_id, :category_id=>task.issue_category_id, :assigned_to_id=>task.assigned_to_id, :author_id=>task.author_id, :subject=>subject, :description=>description);
-      issue.start_date ||= Date.today if task.set_start_date?
-      if task.due_date_number
-        due_date = task.due_date_number
-        due_date_units = task.due_date_units
-        issue.due_date = due_date.send(due_date_units.downcase).from_now
-      end
+      issue = task.generate_issue(now)
       begin
         issue.save!
         task.last_error = nil unless task.last_error.blank?

--- a/lib/scheduled_tasks_checker.rb
+++ b/lib/scheduled_tasks_checker.rb
@@ -31,7 +31,13 @@ class ScheduledTasksChecker
         due_date_units = task.due_date_units
         issue.due_date = due_date.send(due_date_units.downcase).from_now
       end
-      issue.save!
+      begin
+        issue.save!
+        task.last_error = nil unless task.last_error.blank?
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.error "ScheduledTasksChecker: #{e.message}"
+        task.last_error = e.message
+      end
       interval = task.interval_number
       units = task.interval_units
 


### PR DESCRIPTION
What's inside:

- Issue creation (by `Periodictask`) can fail for many causes and not all of them can be handled automatically (e.g., when the assignee no longer has rights to own issues of the project). Therefore, for this kind of problems it's important to keep track of any errors raised during the issue creation. For this reason in one of the commits I'm capturing such errors and saving them in the periodic task. This allows to show these errors to users later, when they are editing the task or viewing the project's task list, in this way helping them discover and resolve the causes.
- Currently, if an issue custom field is required, issue creation will fail (#16). There is no other solution to this problem except adding a default value for the custom field or making it optional. This PR changes this by adding issue custom fields to the periodic task form. Values, specified for the custom fields, are saved into a serialized field of `Periodictask` and then used for creating issues.
- Currently, if a project with periodic tasks is removed, the plugin will fail to run any tasks (#76). This happens because project's periodic tasks remain in the database (and Redmine can't find the project and therefore crashes). The fix (in one of the commits) tells Redmine to remove project's periodic tasks with the project.
- Currently, the plugin depends on version 0.7.6 of the gem `business_time` (exactly 0.7.6, not below or above), which is quite an old version. I changed `Gemfile` to require 0.7.6 or above.

In commits you'll find more comments and screenshots.