### PR TITLE
fixing port-number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To help developing this plugin there is a Vagrantfile working, you can use it wi
     vagrant up --provider lxc
     vagrant ssh -c "/app/redmine/bin/rails server -b0.0.0.0 -p8888"
 
-Then go to http://192.168.2.100:888/ and login with
+Then go to http://192.168.2.100:8888/ and login with
 
     user: admin
     pass: admin


### PR DESCRIPTION
by chance I've seen that in README.md there is a small bug.
first create a vagrant on port 8888, then the browser should connect to port 888 :)