### PR TITLE
Feature: Add parent task to periodic tasks

### DIFF
--- a/app/models/periodictask.rb
+++ b/app/models/periodictask.rb
@@ -41,7 +41,7 @@ class Periodictask < ActiveRecord::Base
       subj = parse_macro(subject.try(:dup), now)
       desc = parse_macro(description.try(:dup), now)
 
-      issue = Issue.new(:project_id => project_id, :tracker_id => tracker_id || project.trackers.first.try(:id), :category_id => issue_category_id,
+      issue = Issue.new(:project_id => project_id, :tracker_id => tracker_id || project.trackers.first.try(:id), :category_id => issue_category_id , :parent_id => parent_id,
                         :assigned_to_id => assigned_to_id, :author_id => author_id,
                         :subject => subj, :description => desc)
       issue.start_date ||= now.to_date if set_start_date?

--- a/app/views/periodictask/_form.html.erb
+++ b/app/views/periodictask/_form.html.erb
@@ -13,6 +13,9 @@
     <% end %>
   </p>
   <p>
+    <%= label(:periodictask, :parent_id, l(:label_parent_id)) %><%= f.number_field :parent_id, step: :any %>
+  </p>
+  <p>
     <%= label(:periodictask, :assigned_to_user_id, l(:label_assigned_to_user)) %>
     <% if @assignables.length > 0 %>
       <%= f.select :assigned_to_id, principals_options_for_select(@assignables, @periodictask.assigned_to), :include_blank => true, :required => true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
   label_estimated_hours_after: Hours
   label_description: Description
   label_issue_category: Issue Category
+  label_parent_id: Issue Parent task
   label_unit_day: day(s)
   label_unit_business_day: business day(s)
   label_unit_week: week(s)

--- a/db/migrate/20231223141012_add_parent_id_to_periodictasks.rb
+++ b/db/migrate/20231223141012_add_parent_id_to_periodictasks.rb
@@ -1,0 +1,11 @@
+active_record_migration_class = ActiveRecord::Migration.respond_to?(:current_version) ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration
+
+class AddParentIdToPeriodictasks < active_record_migration_class
+  def self.up
+    add_column :periodictasks, :parent_id, :integer, :null => true, :default => nil
+  end
+
+  def self.down
+    remove_column :periodictasks, :parent_id
+  end
+end

--- a/test/fixtures/periodictasks.yml
+++ b/test/fixtures/periodictasks.yml
@@ -4,6 +4,7 @@ one:
   project_id: 1
   tracker_id: 1
   issue_category_id: 1
+  parent_id: 1
   assigned_to_id: 1
   author_id: 1
   subject: MyString
@@ -17,6 +18,7 @@ two:
   project_id: 1
   tracker_id: 1
   issue_category_id: 1
+  parent_id: 1
   assigned_to_id: 1
   author_id: 1
   subject: MyString


### PR DESCRIPTION
It has been tested on Redmine 5.0.6. And I think #107 & #108 could be resolved by this.

If the specific parent task exists (no matter if the status is closed or not), new issues will be created with the target parent task.
If specifying a non-existent parent task, they'll be created without any parent task.
However, if specifying a valid parent task in advanced and then adding a new following relationship which is later than the corresponding next run date, the new issues would be failed to create. (Please refer to the following image.) This behavior is acceptable for me so I just mentions it.
![Screenshot 2023-12-24 16 56 19](https://github.com/jperelli/Redmine-Periodic-Task/assets/13884497/43312bb9-921d-4edf-a3d9-5047655fa3b8)
