### PR TITLE
Run scheduled issue generation as the task author (fixes #67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add configurable issue `status` **requires migration** (@jperelli)
 - Show the configured default `priority` in form and detail labels (@jperelli)
 
+### Fixes
+
+- Generate scheduled issues as the task author (`User.current`) so permission-based validations from other plugins, e.g. Luxury Buttons tracker roles, pass under cron/rake (#67)
+
 ## v6.2.0 - 2026-06-30
 
 ### Features

--- a/lib/scheduled_tasks_checker.rb
+++ b/lib/scheduled_tasks_checker.rb
@@ -5,24 +5,38 @@ class ScheduledTasksChecker
       # replace variables (set locale from shell)
       I18n.locale = ENV['LOCALE'] || I18n.default_locale
 
-      issue = task.generate_issue(now)
-      if issue
-        begin
-          issue.save!
-          task.fill_watchers(issue)
-          task.record_generated_issue(issue)
-          task.last_error = nil
-        rescue ActiveRecord::RecordInvalid => e
-          Rails.logger.error "ScheduledTasksChecker: #{e.message}"
-          task.last_error = e.message
+      as_user(task.author) do
+        issue = task.generate_issue(now)
+        if issue
+          begin
+            issue.save!
+            task.fill_watchers(issue)
+            task.record_generated_issue(issue)
+            task.last_error = nil
+          rescue ActiveRecord::RecordInvalid => e
+            Rails.logger.error "ScheduledTasksChecker: #{e.message}"
+            task.last_error = e.message
+          end
+          task.next_run_date = task.get_next_run_date(now)
+        else
+          msg = 'Project is missing or closed'
+          Rails.logger.error "ScheduledTasksChecker: #{msg}"
+          task.last_error = msg
         end
-        task.next_run_date = task.get_next_run_date(now)
-      else
-        msg = 'Project is missing or closed'
-        Rails.logger.error "ScheduledTasksChecker: #{msg}"
-        task.last_error = msg
+        task.save
       end
-      task.save
     end
+  end
+
+  # Runs the block with User.current set to +user+ so permission-based
+  # validations (Redmine's own and other plugins', e.g. Luxury Buttons'
+  # per-tracker role restrictions) evaluate against the task author rather
+  # than Anonymous, which is what User.current resolves to under rake/cron.
+  def self.as_user(user)
+    previous = User.current
+    User.current = user if user
+    yield
+  ensure
+    User.current = previous
   end
 end

--- a/test/unit/periodictasks_test.rb
+++ b/test/unit/periodictasks_test.rb
@@ -314,6 +314,30 @@ class PeriodictasksTest < ActiveSupport::TestCase
     assert_nil task.last_error
   end
 
+  def test_checker_runs_as_task_author_and_restores_current_user
+    Periodictask.create!(
+      project: @project,
+      tracker_id: 1,
+      author_id: 2,
+      subject: 'Current user test',
+      interval_number: 1,
+      interval_units: 'month',
+      next_run_date: 1.day.ago
+    )
+
+    seen = nil
+    Periodictask.any_instance.expects(:fill_watchers).with do |_issue|
+      seen = User.current.id
+      true
+    end
+
+    User.current = nil
+    ScheduledTasksChecker.checktasks!
+
+    assert_equal 2, seen
+    assert User.current.anonymous?
+  end
+
   def test_checker_records_generated_issue_in_history
     task = Periodictask.create!(
       project: @project,


### PR DESCRIPTION
## Summary

Fixes #67 (Luxury Buttons incompatibility). The issue is still applicable: `ScheduledTasksChecker.checktasks!` runs from rake/cron where `User.current` is `AnonymousUser`. Luxury Buttons adds an `Issue` validation ("You couldn't save issues with this tracker") that checks whether `User.current` has a role allowed for the tracker; Anonymous never does, so `save!` fails, the error is stored in `last_error`, and `next_run_date` still advances — exactly the symptom in the ticket. The same root cause/fix was applied in nutso/redmine-plugin-recurring-tasks#61.

Change: wrap each task's generation in `ScheduledTasksChecker.as_user(task.author)`:

```ruby
def self.as_user(user)
  previous = User.current
  User.current = user if user
  yield
ensure
  User.current = previous
end
```

so `generate_issue` / `save!` / `fill_watchers` / `record_generated_issue` all run as the task author, and `User.current` is restored afterwards. Tasks without an author keep the previous behavior.

Adds a unit test (mocha `expects(...).with { }` on `fill_watchers`) asserting `User.current` is the author during the run and Anonymous after; CHANGELOG entry under Unreleased/Fixes.

Not verified against Luxury Buttons itself (obfuscated, paid plugin); verified the full plugin test suite on `6.0-bookworm` and rubocop.

Link to Devin session: https://app.devin.ai/sessions/64ea2194d4384392b0c0f2d645d72902
Open in Devin Desktop: https://app.devin.ai/desktop/session/64ea2194d4384392b0c0f2d645d72902?variant=devin
Requested by: @jperelli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled issues generated by recurring tasks now run under the task author’s permissions, allowing permission-based validations to complete successfully.
  * The previously active user context is restored after scheduled processing finishes.

* **Documentation**
  * Added an Unreleased changelog entry describing the scheduled issue generation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->