### PR TITLE
Parse and render next_run_date in the user's display time zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add configurable issue `status` **requires migration** (@jperelli)
 - Show the configured default `priority` in form and detail labels (@jperelli)
 
+### Fixes
+
+- Parse and render the `next run date` in the user's Redmine time zone, and show the applied zone next to the input with a link to change it (@jperelli, #137)
+
 ## v6.2.0 - 2026-06-30
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Parse and render the `next run date` in the user's Redmine time zone, and show the applied zone next to the input with a link to change it (@jperelli, #137)
+- Use the user's time zone for `next run date` and show it next to the input (@jperelli, #137)
 
 ## v6.2.0 - 2026-06-30
 

--- a/app/controllers/periodictask_controller.rb
+++ b/app/controllers/periodictask_controller.rb
@@ -193,7 +193,7 @@ class PeriodictaskController < ApplicationController
   def assign_periodictask_params
     attrs = periodictask_params
     if attrs[:next_run_date].present?
-      attrs[:next_run_date] = helpers.periodictask_time_zone.parse(attrs[:next_run_date].to_s)
+      attrs[:next_run_date] = helpers.periodictask_parse_time(attrs[:next_run_date].to_s)
     end
     @periodictask.attributes = attrs
   end

--- a/app/controllers/periodictask_controller.rb
+++ b/app/controllers/periodictask_controller.rb
@@ -74,7 +74,7 @@ class PeriodictaskController < ApplicationController
       params[:periodictask][:next_run_date] = @periodictask.get_next_run_date(Time.current)
     end
 
-    @periodictask.attributes = periodictask_params
+    assign_periodictask_params
     @issue = @periodictask.generate_issue
     if @issue.valid? && @periodictask.save
       @periodictask.log_activity('create')
@@ -95,7 +95,7 @@ class PeriodictaskController < ApplicationController
   def update
     @periodictask = Periodictask.accessible.find(params[:id])
     params[:periodictask][:project_id] = @project[:id]
-    @periodictask.attributes = periodictask_params
+    assign_periodictask_params
     @issue = @periodictask.generate_issue
     if @issue.valid? && @periodictask.save
       @periodictask.log_activity('update')
@@ -165,7 +165,7 @@ class PeriodictaskController < ApplicationController
                     else
                       Periodictask.new(project: @project, author_id: User.current.id)
                     end
-    @periodictask.attributes = periodictask_params
+    assign_periodictask_params
     @issue = @periodictask.generate_issue
   end
 
@@ -186,6 +186,16 @@ class PeriodictaskController < ApplicationController
   def load_categories
     # Get the issue categories
     @categories = @project.issue_categories
+  end
+
+  # The form posts next_run_date as a wall-clock time without an offset; parse
+  # it in the same zone the list/show pages use to display it (format_time).
+  def assign_periodictask_params
+    attrs = periodictask_params
+    if attrs[:next_run_date].present?
+      attrs[:next_run_date] = helpers.periodictask_time_zone.parse(attrs[:next_run_date].to_s)
+    end
+    @periodictask.attributes = attrs
   end
 
   def periodictask_params

--- a/app/helpers/periodictask_helper.rb
+++ b/app/helpers/periodictask_helper.rb
@@ -17,6 +17,25 @@ module PeriodictaskHelper
     ["(#{l(:label_default)})", value].compact.join(' - ')
   end
 
+  # Zone in which Redmine's format_time renders times for the current user:
+  # the user's preference when set, otherwise the server's local zone.
+  def periodictask_time_zone
+    User.current.time_zone || ActiveSupport::TimeZone[Time.now.utc_offset]
+  end
+
+  # Value for the next_run_date datetime-local input, in the display zone.
+  def periodictask_next_run_date_input_value(time)
+    time&.in_time_zone(periodictask_time_zone)&.strftime('%Y-%m-%dT%H:%M')
+  end
+
+  # Zone name and UTC offset shown next to the next_run_date input.
+  def periodictask_time_zone_label
+    return User.current.time_zone.to_s if User.current.time_zone
+
+    now = Time.now
+    "(GMT#{now.formatted_offset}) #{now.zone}"
+  end
+
   # Formatted time for display, with the full ISO 8601 timestamp (including the
   # timezone offset) shown as a tooltip on hover.
   def periodictask_time_with_title(time)

--- a/app/helpers/periodictask_helper.rb
+++ b/app/helpers/periodictask_helper.rb
@@ -17,15 +17,20 @@ module PeriodictaskHelper
     ["(#{l(:label_default)})", value].compact.join(' - ')
   end
 
-  # Zone in which Redmine's format_time renders times for the current user:
-  # the user's preference when set, otherwise the server's local zone.
-  def periodictask_time_zone
-    User.current.time_zone || ActiveSupport::TimeZone[Time.now.utc_offset]
+  # Parses a wall-clock datetime (no offset) in the zone Redmine's format_time
+  # uses for the current user: their preference when set, otherwise the
+  # server's local zone.
+  def periodictask_parse_time(value)
+    zone = User.current.time_zone
+    zone ? zone.parse(value) : Time.parse(value)
   end
 
   # Value for the next_run_date datetime-local input, in the display zone.
   def periodictask_next_run_date_input_value(time)
-    time&.in_time_zone(periodictask_time_zone)&.strftime('%Y-%m-%dT%H:%M')
+    return if time.blank?
+
+    zone = User.current.time_zone
+    (zone ? time.in_time_zone(zone) : time.getlocal).strftime('%Y-%m-%dT%H:%M')
   end
 
   # Zone name and UTC offset shown next to the next_run_date input.

--- a/app/views/periodictask/_form.html.erb
+++ b/app/views/periodictask/_form.html.erb
@@ -13,7 +13,7 @@
   <p>
     <%= label(:periodictask, :next_run_date, l(:label_next_run_date)) %>
     <%= f.datetime_field :next_run_date, :value => periodictask_next_run_date_input_value(@periodictask.next_run_date) %>
-    <span class="periodictask-time-zone"><%= periodictask_time_zone_label %></span>
+    <span class="periodictask-time-zone"><%= link_to periodictask_time_zone_label, my_account_path, :title => l(:label_my_account) %></span>
   </p>
   <p>
     <%= label(:periodictask, :author_id, l(:label_issue_author)) %>

--- a/app/views/periodictask/_form.html.erb
+++ b/app/views/periodictask/_form.html.erb
@@ -12,7 +12,8 @@
   </p>
   <p>
     <%= label(:periodictask, :next_run_date, l(:label_next_run_date)) %>
-    <%= f.datetime_field :next_run_date %>
+    <%= f.datetime_field :next_run_date, :value => periodictask_next_run_date_input_value(@periodictask.next_run_date) %>
+    <span class="periodictask-time-zone"><%= periodictask_time_zone_label %></span>
   </p>
   <p>
     <%= label(:periodictask, :author_id, l(:label_issue_author)) %>

--- a/app/views/periodictask/_form.html.erb
+++ b/app/views/periodictask/_form.html.erb
@@ -13,7 +13,7 @@
   <p>
     <%= label(:periodictask, :next_run_date, l(:label_next_run_date)) %>
     <%= f.datetime_field :next_run_date, :value => periodictask_next_run_date_input_value(@periodictask.next_run_date) %>
-    <span class="periodictask-time-zone"><%= link_to periodictask_time_zone_label, my_account_path, :title => l(:label_my_account) %></span>
+    <span class="periodictask-time-zone"><%= link_to periodictask_time_zone_label, my_account_path, :title => l(:label_my_account), :target => '_blank', :rel => 'noopener' %></span>
   </p>
   <p>
     <%= label(:periodictask, :author_id, l(:label_issue_author)) %>
@@ -165,5 +165,17 @@
     $('#watchers_inputs').closest('form').on('submit', function() {
       $(this).find('input[name="issue[watcher_user_ids][]"]').attr('name', 'periodictask[watcher_user_ids][]');
     });
+
+    <% if User.current.pref.warn_on_leaving_unsaved == '1' %>
+    // Redmine's warnLeavingUnsaved only watches textareas; also guard the
+    // rest of the form so navigating away mid-edit asks for confirmation.
+    var form = $('#periodictask_next_run_date').closest('form');
+    var unsaved = false;
+    form.on('change', ':input', function() { unsaved = true; });
+    form.on('submit', function() { unsaved = false; });
+    $(window).on('beforeunload', function() {
+      if (unsaved) { return '<%= escape_javascript l(:text_warn_on_leaving_unsaved) %>'; }
+    });
+    <% end %>
   });
 <% end %>

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -191,7 +191,7 @@ class PeriodictaskControllerTest < ActionController::TestCase
     get :edit, params: { project_id: 'ecookbook', id: task.id }
 
     assert_select '#periodictask_next_run_date[value="2026-08-20T09:00"]'
-    assert_select 'span.periodictask-time-zone a[href=?]', '/my/account', text: '(GMT-03:00) Buenos Aires'
+    assert_select 'span.periodictask-time-zone a[href=?][target="_blank"]', '/my/account', text: '(GMT-03:00) Buenos Aires'
   end
 
   def test_next_run_date_round_trips_in_server_zone_without_user_time_zone

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -191,7 +191,8 @@ class PeriodictaskControllerTest < ActionController::TestCase
     get :edit, params: { project_id: 'ecookbook', id: task.id }
 
     assert_select '#periodictask_next_run_date[value="2026-08-20T09:00"]'
-    assert_select 'span.periodictask-time-zone a[href=?][target="_blank"]', '/my/account', text: '(GMT-03:00) Buenos Aires'
+    assert_select 'span.periodictask-time-zone a[href=?][target="_blank"]', '/my/account',
+                  text: '(GMT-03:00) Buenos Aires'
   end
 
   def test_next_run_date_round_trips_in_server_zone_without_user_time_zone

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -171,6 +171,29 @@ class PeriodictaskControllerTest < ActionController::TestCase
     assert_equal 'week', task.interval_units
   end
 
+  def test_update_parses_next_run_date_in_user_time_zone
+    User.find(2).pref.update!(time_zone: 'Buenos Aires') # UTC-3, no DST
+    task = create_test_periodictask
+    patch :update, params: {
+      project_id: 'ecookbook',
+      id: task.id,
+      periodictask: { next_run_date: '2026-08-20T09:00' }
+    }
+    task.reload
+    assert_equal Time.utc(2026, 8, 20, 12, 0), task.next_run_date.utc
+    assert_equal '2026-08-20 09:00', task.next_run_date.in_time_zone('Buenos Aires').strftime('%Y-%m-%d %H:%M')
+  end
+
+  def test_edit_shows_next_run_date_and_zone_in_user_time_zone
+    User.find(2).pref.update!(time_zone: 'Buenos Aires')
+    task = create_test_periodictask(next_run_date: Time.utc(2026, 8, 20, 12, 0))
+
+    get :edit, params: { project_id: 'ecookbook', id: task.id }
+
+    assert_select '#periodictask_next_run_date[value="2026-08-20T09:00"]'
+    assert_select 'span.periodictask-time-zone', text: '(GMT-03:00) Buenos Aires'
+  end
+
   def test_show
     task = create_test_periodictask
     get :show, params: { project_id: 'ecookbook', id: task.id }

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -194,6 +194,21 @@ class PeriodictaskControllerTest < ActionController::TestCase
     assert_select 'span.periodictask-time-zone', text: '(GMT-03:00) Buenos Aires'
   end
 
+  def test_next_run_date_round_trips_in_server_zone_without_user_time_zone
+    User.find(2).pref.update!(time_zone: '')
+    task = create_test_periodictask
+    patch :update, params: {
+      project_id: 'ecookbook',
+      id: task.id,
+      periodictask: { next_run_date: '2026-08-20T10:00' }
+    }
+    task.reload
+    assert_equal '2026-08-20 10:00', task.next_run_date.getlocal.strftime('%Y-%m-%d %H:%M')
+
+    get :edit, params: { project_id: 'ecookbook', id: task.id }
+    assert_select '#periodictask_next_run_date[value="2026-08-20T10:00"]'
+  end
+
   def test_show
     task = create_test_periodictask
     get :show, params: { project_id: 'ecookbook', id: task.id }

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -191,7 +191,7 @@ class PeriodictaskControllerTest < ActionController::TestCase
     get :edit, params: { project_id: 'ecookbook', id: task.id }
 
     assert_select '#periodictask_next_run_date[value="2026-08-20T09:00"]'
-    assert_select 'span.periodictask-time-zone', text: '(GMT-03:00) Buenos Aires'
+    assert_select 'span.periodictask-time-zone a[href=?]', '/my/account', text: '(GMT-03:00) Buenos Aires'
   end
 
   def test_next_run_date_round_trips_in_server_zone_without_user_time_zone


### PR DESCRIPTION
## Summary
Fixes #137 (enter 09:00, list shows 06:00).

Root cause: the form's `datetime_field` posts a wall-clock value with no offset (`2026-08-20T09:00`). ActiveRecord parsed it in Rails' `Time.zone`, which is UTC in Redmine (`config.time_zone` is unset), while the list/show pages render `next_run_date` via Redmine's `format_time`, which converts to `User.current.time_zone` (or the server's local zone when unset). The edit form re-rendered the raw UTC value, so it *looked* consistent while the list showed a shifted time — 3h for the UTC-3 reporter.

Fix: use one zone for both directions, the same one `format_time` uses.

```ruby
# helper
def periodictask_time_zone
  User.current.time_zone || ActiveSupport::TimeZone[Time.now.utc_offset]
end

# controller (create/update/customfields)
attrs[:next_run_date] = helpers.periodictask_time_zone.parse(attrs[:next_run_date].to_s) if present
@periodictask.attributes = attrs
```

The parse is done explicitly instead of `Time.use_zone { attributes = ... }` because AR casts time-zone-aware attributes lazily, so the zone in effect at assignment time is not what gets used.

The edit form now renders the value with `in_time_zone(periodictask_time_zone)` and shows the applied zone after the input (e.g. `(GMT-03:00) Buenos Aires`, or `(GMT+02:00) CEST` when the user has no Redmine time zone set). Stored values are unchanged (UTC), so the cron comparison against `Time.current` is unaffected.

Tests: functional round-trip in a UTC-3 user zone (post `09:00` → stored `12:00Z`; edit renders `09:00` + zone label). Ran the Redmine 6.1 test image and rubocop locally.

Link to Devin session: https://app.devin.ai/sessions/c13ea2aa60c241a7a0603959c03f7863
Open in Devin Desktop: https://app.devin.ai/desktop/session/c13ea2aa60c241a7a0603959c03f7863?variant=devin
Requested by: @jperelli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Next-run dates are now interpreted using the user’s configured time zone and displayed beside the input.
  - Users without a configured time zone continue to receive consistent local-time handling.
  - Added a link to time-zone settings from the scheduling form.

- **Enhancements**
  - Forms can warn users before leaving with unsaved changes when this preference is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->