### PR TITLE
Support Redmine 7.0 (v7.0.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           - '5.1-bookworm'
           - '6.0-bookworm'
           - '6.1-bookworm'
+          - '7.0-bookworm'
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@
 - Add configurable issue `status` **requires migration** (@jperelli)
 - Show the configured default `priority` in form and detail labels (@jperelli)
 - Add RedmineUP Tags plugin support: configured tags are added to generated issues **requires migration** (#138)
+- Support Redmine 7.0 (Rails 8.1 / Ruby 4.0) (@jperelli)
 
 ### Fixes
 
 - Generate scheduled issues as the task author (`User.current`) so permission-based validations from other plugins, e.g. Luxury Buttons tracker roles, pass under cron/rake (#67)
-
-### Fixes
-
 - Use the user's time zone for `next run date` and show it next to the input (@jperelli, #137)
+
+### Chore
+
+- Add Redmine 7.0 to the CI test matrix and bump the dev docker image to 7.0 (@jperelli)
+- Replace the removed `bundle install --with` flag with `BUNDLE_WITH` in the Dockerfiles, required by Bundler 4 shipped with Redmine 7.0 (@jperelli)
 
 ## v6.2.0 - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v7.0.0 - 2026-09-03
+
+### Features
+
+- Support Redmine 7.0 (Rails 8.1 / Ruby 4.0) (@jperelli)
+
+### Chore
+
+- Add Redmine 7.0 to the CI test matrix and bump the dev docker image to 7.0 (@jperelli)
+- Replace the removed `bundle install --with` flag with `BUNDLE_WITH` in the Dockerfiles, required by Bundler 4 shipped with Redmine 7.0 (@jperelli)
+
 ## v6.3.0 - 2026-09-03
 
 ### Features
@@ -7,17 +18,11 @@
 - Add configurable issue `status` **requires migration** (@jperelli)
 - Show the configured default `priority` in form and detail labels (@jperelli)
 - Add RedmineUP Tags plugin support: configured tags are added to generated issues **requires migration** (#138)
-- Support Redmine 7.0 (Rails 8.1 / Ruby 4.0) (@jperelli)
 
 ### Fixes
 
 - Generate scheduled issues as the task author (`User.current`) so permission-based validations from other plugins, e.g. Luxury Buttons tracker roles, pass under cron/rake (#67)
 - Use the user's time zone for `next run date` and show it next to the input (@jperelli, #137)
-
-### Chore
-
-- Add Redmine 7.0 to the CI test matrix and bump the dev docker image to 7.0 (@jperelli)
-- Replace the removed `bundle install --with` flag with `BUNDLE_WITH` in the Dockerfiles, required by Bundler 4 shipped with Redmine 7.0 (@jperelli)
 
 ## v6.2.0 - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v7.0.0 - 2026-09-03
+## v7.0.0 - (unreleased)
 
 ### Features
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM redmine:6.1-bookworm
+FROM redmine:7.0-bookworm
 
 RUN echo "development:\n  adapter: sqlite3\n  database: /usr/src/redmine/sqlite/redmine.db" > /usr/src/redmine/config/database.yml
 RUN mkdir -p /usr/src/redmine/sqlite
@@ -6,7 +6,8 @@ RUN chown -R 999:999 /usr/src/redmine/sqlite
 
 RUN apt update && apt install -y gcc make
 COPY ./Gemfile /usr/src/redmine/plugins/periodictask/Gemfile
-RUN bundle install --with=development
+ENV BUNDLE_WITH=development
+RUN bundle install
 
 ENTRYPOINT [ "" ]
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y gcc make && rm -rf /var/lib/apt/lists/*
 # Copy plugin
 COPY . /usr/src/redmine/plugins/periodictask/
 
-RUN bundle install --with test
+ENV BUNDLE_WITH=test
+RUN bundle install
 
 # Prepare test database
 RUN bundle exec rake db:migrate RAILS_ENV=test

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you cannot migrate to a newer version and still need support, you can hire me
 <table>
   <tr>
     <td rowspan="2">git branch</td>
-    <td colspan="6">redmine version support</td>
+    <td colspan="9">redmine version support</td>
   </tr>
   <tr>
     <td>1.x</td>
@@ -40,6 +40,7 @@ If you cannot migrate to a newer version and still need support, you can hire me
     <td>5.1</td>
     <td>6.0</td>
     <td>6.1</td>
+    <td>7.0</td>
   </tr>
   <tr>
     <td>main</td>
@@ -48,6 +49,7 @@ If you cannot migrate to a newer version and still need support, you can hire me
     <td>?</td>
     <td>?</td>
     <td>?</td>
+    <td>✅</td>
     <td>✅</td>
     <td>✅</td>
     <td>✅</td>
@@ -62,11 +64,13 @@ If you cannot migrate to a newer version and still need support, you can hire me
     <td>🚫</td>
     <td>🚫</td>
     <td>🚫</td>
+    <td>🚫</td>
   </tr>
   <tr>
     <td>redmine2</td>
     <td>✅</td>
     <td>✅</td>
+    <td>🚫</td>
     <td>🚫</td>
     <td>🚫</td>
     <td>🚫</td>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - redmine_fix_permissions
 
   redmine_fix_permissions:
-    image: redmine:6.1-bookworm
+    image: redmine:7.0-bookworm
     volumes:
       - ./.volumes/sqlite:/usr/src/redmine/sqlite
     command: >

--- a/init.rb
+++ b/init.rb
@@ -15,7 +15,7 @@ Redmine::Plugin.register :periodictask do
   name 'Redmine Periodictask plugin'
   author 'Julian Perelli'
   description 'Plugin to create a task periodically by defining an interval'
-  version '6.3.0'
+  version '7.0.0'
   url 'https://github.com/jperelli/Redmine-Periodic-Task/'
   author_url 'https://jperelli.com.ar/'
 


### PR DESCRIPTION
## Summary

Verified the plugin against `redmine:7.0-bookworm` (Redmine 7.0.1 / Rails 8.1.3 / Ruby 4.0.6): the full plugin suite (104 runs) plus the standalone `get_next_run_date_test.rb` and `timezone_test.rb` pass with no code changes and no deprecation warnings. Also re-ran 5.1 to confirm the Dockerfile change is backwards compatible.

The only breakage was in the Docker build: Bundler 4 (shipped with Ruby 4 / Redmine 7) removed `bundle install --with`, so `Dockerfile.test` and `Dockerfile` now use the `BUNDLE_WITH` env var instead, which works on every version in the matrix.

```diff
-RUN bundle install --with test
+ENV BUNDLE_WITH=test
+RUN bundle install
```

Other changes: plugin version bumped to `7.0.0` in `init.rb` with a new `v7.0.0` CHANGELOG section; dev `Dockerfile`/`docker-compose.yml` bumped to `redmine:7.0-bookworm`; README support table gains a 7.0 column.

**Not included (needs manual step):** adding `'7.0-bookworm'` to the `redmine-tag` matrix in `.github/workflows/test.yml`. The push was rejected because the git token lacks the `workflow` scope. Please add that one line to the matrix on this branch:

```yaml
          - '6.1-bookworm'
          - '7.0-bookworm'
```


Link to Devin session: https://app.devin.ai/sessions/85c23e588d644043af7c5d80994e5c40
Open in Devin Desktop: https://app.devin.ai/desktop/session/85c23e588d644043af7c5d80994e5c40?variant=devin
Requested by: @jperelli