### PR TITLE
Add Spanish translation (supersedes #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support Redmine 7.0 (Rails 8.1 / Ruby 4.0) (@jperelli)
 - Add configurable `subtasks` and `related issues`: each generated issue gets the configured child issues and relations **requires migration** (@jperelli)
+- Add spanish translation ([#136](https://github.com/jperelli/Redmine-Periodic-Task/pull/136)) (@lupa18)
 
 ### Chore
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ You can use the following variables in the subject and description of a periodic
 | `**PREVIOUS_MONTH**` | Previous month, zero-padded (01..12) |
 | `**PREVIOUS_MONTHNAME**` | Full name of the previous month, localized |
 
-If you want to get localized month names, please add `LOCALE="de"` (available are `de`, `en`, `ja`, `ru`, `tr`, `zh`) to the cronjob like this
+If you want to get localized month names, please add `LOCALE="de"` (available are `bg`, `de`, `en`, `es`, `hr`, `it`, `ja`, `pl`, `pt-BR`, `ru`, `tr`, `uk`, `zh`) to the cronjob like this
 
     0 * * * * cd /opt/redmine && /usr/local/bin/bundle exec rake redmine:check_periodictasks RAILS_ENV=production LOCALE="de"
 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -53,8 +53,9 @@ es:
   label_last_error: Último error
   label_issue_custom_fields: Campos personalizados de la incidencia
   label_priority: Prioridad
-  label_priority_default: (Predeterminada - Normal)
   label_watchers: Seguidores
+  label_tags: Etiquetas
+  label_tags_info: "Etiquetas separadas por comas que se añaden a cada incidencia creada (complemento RedmineUP Tags)."
   label_periodictask_template: Plantilla
   label_periodictask_history: Incidencias generadas
   label_periodictask_no_history: Esta tarea aún no ha generado ninguna incidencia
@@ -66,3 +67,8 @@ es:
   label_periodictask_journal_run: Tarea periódica corrida
   label_periodictask_plugin_name: Complemento Periodic Task
   label_periodictask_credit_by: por
+  label_subtasks_info: "Incidencias hijas creadas bajo cada incidencia generada. Los asuntos aceptan las mismas variables que el asunto de la incidencia."
+  label_relations_info: "Relaciones creadas desde cada incidencia generada hacia incidencias existentes."
+  error_subtask_subject_blank: "El asunto de la subtarea no puede estar en blanco"
+  error_relation_type_invalid: "Tipo de relación no válido"
+  error_relation_issue_invalid: "La incidencia relacionada debe ser un número de incidencia"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,4 @@
 # Spanish strings go here for Rails i18n
-```yaml
 es:
   label_tracker: Tracker
   label_issue_author: Autor de la incidencia
@@ -67,4 +66,3 @@ es:
   label_periodictask_journal_run: Tarea periódica corrida
   label_periodictask_plugin_name: Complemento de tareas periódicas
   label_periodictask_credit_by: por
-```

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,6 +1,6 @@
 # Spanish strings go here for Rails i18n
 es:
-  label_tracker: Tracker
+  label_tracker: Tipo
   label_issue_author: Autor de la incidencia
   label_periodictask_configuration: Configuración de tareas periódicas
   no_members_in_project: Este proyecto no tiene miembros
@@ -64,5 +64,5 @@ es:
   label_periodictask_journal_update: Tarea periódica actualizada
   label_periodictask_journal_delete: Tarea periódica eliminada
   label_periodictask_journal_run: Tarea periódica corrida
-  label_periodictask_plugin_name: Complemento de tareas periódicas
+  label_periodictask_plugin_name: Complemento Periodic Task
   label_periodictask_credit_by: por

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,70 @@
+# Spanish strings go here for Rails i18n
+```yaml
+es:
+  label_tracker: Tracker
+  label_issue_author: Autor de la incidencia
+  label_periodictask_configuration: Configuración de tareas periódicas
+  no_members_in_project: Este proyecto no tiene miembros
+  no_categories_in_project: Este proyecto no tiene categorías
+  label_subject: Asunto
+  label_next_run_date: Próxima ejecución
+  label_last_run: Última ejecución
+  label_edit_periodic_task: Editar tarea periódica
+  label_new_periodic_task: Nueva tarea periódica
+  label_periodic_tasks: Tareas periódicas
+  label_periodic_task: Tarea periódica
+  label_create_periodic_task: Crear
+  label_save_periodic_task: Guardar
+  label_scheduled_tasks: Estas son las tareas programadas actualmente
+  label_no_project: No se proporcionó el ID del proyecto
+  label_no_periodic_tasks: Aún no hay tareas periódicas — crea una para comenzar.
+  label_remove_periodic_task: eliminar tarea periódica
+  label_interval: Intervalo
+  label_set_start_date: Establecer fecha de inicio
+  label_set_start_date_info: Cuando está marcada, la fecha de inicio de cada incidencia creada se establece en el día en que se genera.
+  label_due_date: 'Establecer fecha fin después de'
+  label_due_date_info: 'Fecha fin de cada incidencia creada, establecida después de este período de tiempo a partir de su fecha de inicio.'
+  label_estimated_hours: Tiempo estimado
+  label_estimated_hours_after: Horas
+  label_description: Descripción
+  label_unit_day: día(s)
+  label_unit_business_day: día(s) hábil(es)
+  label_unit_week: semana(s)
+  label_unit_month: mes(es)
+  label_unit_year: año(s)
+  flash_task_created: La tarea periódica ha sido creada
+  flash_task_saved: La tarea periódica ha sido guardada
+  flash_task_run_now: 'Incidencia #%{id} creada'
+  flash_task_run_failed: 'No se pudo crear la incidencia: %{error}'
+  button_run_now: Correr ahora
+  text_run_now_confirm: ¿Crear una incidencia ahora a partir de esta tarea periódica? La programación no cambiará.
+  label_project_missing_or_closed: El proyecto no existe o está cerrado
+  subject_variables: |-
+    Variables disponibles:
+    **DAY** (01-31)
+    **WEEK** (00-53)
+    **WEEKISO** (01-53)
+    **MONTH** (01-12)
+    **PREVIOUS_MONTH** (01-12)
+    **QUARTER** (1-4)
+    **YEAR** (AAAA)
+    **MONTHNAME** (Enero - Diciembre)
+    **PREVIOUS_MONTHNAME** (Enero - Diciembre)
+  label_variables_markdown_note: 'Nota: en la descripción, estas variables aparecen en negrita en la vista previa porque ** es la sintaxis de negrita de Markdown; se reemplazan por el valor real cuando se crea la incidencia.'
+  label_last_error: Último error
+  label_issue_custom_fields: Campos personalizados de la incidencia
+  label_priority: Prioridad
+  label_priority_default: (Predeterminada - Normal)
+  label_watchers: Seguidores
+  label_periodictask_template: Plantilla
+  label_periodictask_history: Incidencias generadas
+  label_periodictask_no_history: Esta tarea aún no ha generado ninguna incidencia
+  label_issue_created_by_periodictask: Creada automáticamente por una tarea periódica
+  label_periodictask_plural: Tareas periódicas
+  label_periodictask_journal_create: Tarea periódica añadida
+  label_periodictask_journal_update: Tarea periódica actualizada
+  label_periodictask_journal_delete: Tarea periódica eliminada
+  label_periodictask_journal_run: Tarea periódica corrida
+  label_periodictask_plugin_name: Complemento de tareas periódicas
+  label_periodictask_credit_by: por
+```


### PR DESCRIPTION
## Summary
Lands @lupa18's Spanish locale from #136 (their 3 commits are cherry-picked with authorship preserved) rebased on current `main`, plus a sync commit. #136 was branched from the 6.2.0 release and its fork branch isn't pushable, so it drifted from `en.yml`:

- Added the 7 keys introduced since 6.2.0 (`label_tags`, `label_tags_info`, `label_subtasks_info`, `label_relations_info`, `error_subtask_subject_blank`, `error_relation_type_invalid`, `error_relation_issue_invalid`); without them the form/detail views would render the raw key names in Spanish.
- Dropped `label_priority_default`, which no longer exists in `en.yml` or any view.
- Kept the contributor's wording (`Correr ahora`, `incidencia`) as discussed on #136.
- CHANGELOG entry under v7.0.0 and `es` added to the README `LOCALE` list.

`es.yml` and `en.yml` now have identical key sets. Closes #136.

Link to Devin session: https://app.devin.ai/sessions/278cfff4fca44078af052b7182ac429b
Open in Devin Desktop: https://app.devin.ai/desktop/session/278cfff4fca44078af052b7182ac429b?variant=devin
Requested by: @jperelli