### PR TITLE
Add configurable % Done with progress bar in the detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support Redmine 7.0 (Rails 8.1 / Ruby 4.0) (@jperelli)
 - Add configurable `subtasks` and `related issues`: each generated issue gets the configured child issues and relations **requires migration** (@jperelli)
+- Add configurable `% Done` shown with Redmine's progress bar in the detail page **requires migration** (@jperelli)
 
 ### Chore
 

--- a/app/controllers/periodictask_controller.rb
+++ b/app/controllers/periodictask_controller.rb
@@ -218,7 +218,7 @@ class PeriodictaskController < ApplicationController
       :project_id, :tracker_id, :assigned_to_id, :author_id, :subject,
       :interval_number, :interval_units, :next_run_date, :set_start_date,
       :due_date_number, :due_date_units, :description, :issue_category_id,
-      :estimated_hours, :checklists_template_id, :parent_id, :priority_id, :status_id, :tag_list,
+      :estimated_hours, :checklists_template_id, :parent_id, :priority_id, :status_id, :done_ratio, :tag_list,
       { custom_field_values: {} },
       { watcher_user_ids: [] },
       { subtasks: Periodictask::SUBTASK_KEYS },

--- a/app/models/periodictask.rb
+++ b/app/models/periodictask.rb
@@ -98,6 +98,7 @@ class Periodictask < ActiveRecord::Base
 
   validates :interval_number, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :interval_units, presence: true
+  validates :done_ratio, inclusion: { in: 0..100 }, allow_nil: true
   validate :validate_subtasks_and_relations
 
   scope :accessible, lambda {
@@ -137,6 +138,7 @@ class Periodictask < ActiveRecord::Base
                       subject: subj, description: desc)
     issue.priority_id = priority_id if priority_id.present?
     issue.status_id = status_id if status_id.present?
+    issue.done_ratio = done_ratio if done_ratio.present? && Issue.use_field_for_done_ratio?
     issue.start_date ||= now.to_date if set_start_date?
     if due_date_number
       due_date_units ||= 'day'

--- a/app/models/periodictask.rb
+++ b/app/models/periodictask.rb
@@ -84,6 +84,18 @@ class Periodictask < ActiveRecord::Base
     Issue.method_defined?(:tag_list=) && Issue.respond_to?(:available_tags)
   end
 
+  # Tracker the generated issues will use: the configured one or the project's first.
+  def effective_tracker
+    tracker || project&.trackers&.first
+  end
+
+  # % Done is only usable when Redmine takes it from the issue field (not from
+  # the status) and the tracker has it enabled in its core fields.
+  def done_ratio_enabled?
+    Issue.use_field_for_done_ratio? && effective_tracker.present? &&
+      effective_tracker.core_fields.include?('done_ratio')
+  end
+
   # Accept "h:mm" / "1h30" / decimal input like Redmine's issue estimated time.
   def estimated_hours=(hours)
     write_attribute :estimated_hours, (hours.is_a?(String) ? (hours.to_hours || hours) : hours)
@@ -132,13 +144,13 @@ class Periodictask < ActiveRecord::Base
     desc = parse_macro(description.try(:dup), now)
 
     issue = Issue.new(project_id: project_id,
-                      tracker_id: tracker_id || project.trackers.first.try(:id),
+                      tracker_id: effective_tracker.try(:id),
                       category_id: issue_category_id, parent_id: parent_id,
                       assigned_to_id: assigned_to_id, author_id: author_id,
                       subject: subj, description: desc)
     issue.priority_id = priority_id if priority_id.present?
     issue.status_id = status_id if status_id.present?
-    issue.done_ratio = done_ratio if done_ratio.present? && Issue.use_field_for_done_ratio?
+    issue.done_ratio = done_ratio if done_ratio.present? && done_ratio_enabled?
     issue.start_date ||= now.to_date if set_start_date?
     if due_date_number
       due_date_units ||= 'day'

--- a/app/views/periodictask/_form.html.erb
+++ b/app/views/periodictask/_form.html.erb
@@ -95,10 +95,12 @@
         <%= label(:periodictask, :estimated_hours, l(:label_estimated_hours)) %>
         <%= f.text_field :estimated_hours, :size => 6, :value => format_hours(@periodictask.estimated_hours), :placeholder => 'h:mm' %> <%= l(:label_estimated_hours_after) %>
       </p>
+      <% if Issue.use_field_for_done_ratio? %>
       <p>
-        <label><%= l(:field_done_ratio) %></label>
-        <%= select_tag '', options_for_select([['0 %', 0]]), :disabled => true, :style => 'width: auto' %>
+        <%= label(:periodictask, :done_ratio, l(:field_done_ratio)) %>
+        <%= f.select :done_ratio, ((0..10).to_a.collect { |r| ["#{r * 10} %", r * 10] }), { :include_blank => periodictask_default_label('0 %') }, { :style => 'width: auto' } %>
       </p>
+      <% end %>
     </div>
   </div>
   </div>

--- a/app/views/periodictask/_form.html.erb
+++ b/app/views/periodictask/_form.html.erb
@@ -33,7 +33,7 @@
   </p>
   <p>
     <%= label(:periodictask, :tracker_id, l(:label_tracker)) %>
-    <%= f.select :tracker_id, options_for_select(@project.trackers.map { |tracker| [tracker.name, tracker.id, { 'data-default-status-label' => periodictask_default_label(tracker.default_status&.name) }] }, @periodictask.tracker_id) %>
+    <%= f.select :tracker_id, options_for_select(@project.trackers.map { |tracker| [tracker.name, tracker.id, { 'data-default-status-label' => periodictask_default_label(tracker.default_status&.name), 'data-done-ratio-enabled' => tracker.core_fields.include?('done_ratio') }] }, @periodictask.tracker_id) %>
   </p>
   <p>
     <%= label(:periodictask, :subject) do %><span class="field-description" title="<%= l(:subject_variables) %>"><%= l(:label_subject) %></span> <span class="required">*</span><% end %>
@@ -96,7 +96,7 @@
         <%= f.text_field :estimated_hours, :size => 6, :value => format_hours(@periodictask.estimated_hours), :placeholder => 'h:mm' %> <%= l(:label_estimated_hours_after) %>
       </p>
       <% if Issue.use_field_for_done_ratio? %>
-      <p>
+      <p id="periodictask_done_ratio_field" style="<%= 'display: none;' unless @periodictask.done_ratio_enabled? %>">
         <%= label(:periodictask, :done_ratio, l(:field_done_ratio)) %>
         <%= f.select :done_ratio, ((0..10).to_a.collect { |r| ["#{r * 10} %", r * 10] }), { :include_blank => periodictask_default_label('0 %') }, { :style => 'width: auto' } %>
       </p>
@@ -152,8 +152,14 @@
       $('#periodictask_status_id option[value=""]').text(label);
     }
 
+    function toggleDoneRatioField() {
+      var enabled = $('#periodictask_tracker_id option:selected').attr('data-done-ratio-enabled') === 'true';
+      $('#periodictask_done_ratio_field').toggle(enabled);
+    }
+
     $('#periodictask_tracker_id').change(function() {
       updateDefaultStatusLabel();
+      toggleDoneRatioField();
       $.ajax({
         url: '<%= escape_javascript(periodictask_customfields_path(@project, :format => 'js')) %>',
         type: 'post',

--- a/app/views/periodictask/show.html.erb
+++ b/app/views/periodictask/show.html.erb
@@ -94,6 +94,11 @@
       rows.right l(:label_estimated_hours),
                  (@periodictask.estimated_hours.present? ? "#{@periodictask.estimated_hours} #{l(:label_estimated_hours_after)}" : '-'),
                  class: 'estimated-hours'
+      if Issue.use_field_for_done_ratio?
+        rows.right l(:field_done_ratio),
+                   progress_bar(@periodictask.done_ratio.to_i, legend: "#{@periodictask.done_ratio.to_i}%"),
+                   class: 'progress'
+      end
     end %>
   </div>
 

--- a/app/views/periodictask/show.html.erb
+++ b/app/views/periodictask/show.html.erb
@@ -94,7 +94,7 @@
       rows.right l(:label_estimated_hours),
                  (@periodictask.estimated_hours.present? ? "#{@periodictask.estimated_hours} #{l(:label_estimated_hours_after)}" : '-'),
                  class: 'estimated-hours'
-      if Issue.use_field_for_done_ratio?
+      if @periodictask.done_ratio_enabled?
         rows.right l(:field_done_ratio),
                    progress_bar(@periodictask.done_ratio.to_i, legend: "#{@periodictask.done_ratio.to_i}%"),
                    class: 'progress'

--- a/db/migrate/20260905000000_add_done_ratio_to_periodictasks.rb
+++ b/db/migrate/20260905000000_add_done_ratio_to_periodictasks.rb
@@ -1,0 +1,11 @@
+active_record_migration_class = ActiveRecord::Migration.respond_to?(:current_version) ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration
+
+class AddDoneRatioToPeriodictasks < active_record_migration_class
+  def self.up
+    add_column :periodictasks, :done_ratio, :integer, :null => true, :default => nil
+  end
+
+  def self.down
+    remove_column :periodictasks, :done_ratio
+  end
+end

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -164,6 +164,20 @@ class PeriodictaskControllerTest < ActionController::TestCase
     assert_select '.progress.attribute p.percent', text: '70%'
   end
 
+  def test_done_ratio_hidden_when_tracker_disables_it
+    tracker = Tracker.find(1)
+    tracker.core_fields = tracker.core_fields - ['done_ratio']
+    tracker.save!
+    task = create_test_periodictask(done_ratio: 70)
+
+    get :edit, params: { project_id: 'ecookbook', id: task.id }
+    assert_select '#periodictask_done_ratio_field[style*="display: none"]'
+    assert_select '#periodictask_tracker_id option[value="1"][data-done-ratio-enabled="false"]'
+
+    get :show, params: { project_id: 'ecookbook', id: task.id }
+    assert_select '.progress.attribute', 0
+  end
+
   def test_edit_with_nil_watcher_user_ids
     task = create_test_periodictask
     task.update_column(:watcher_user_ids, nil)

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -97,6 +97,7 @@ class PeriodictaskControllerTest < ActionController::TestCase
           description: 'A test description',
           tracker_id: 1,
           status_id: 5,
+          done_ratio: 40,
           assigned_to_id: 2,
           interval_number: 1,
           interval_units: 'month',
@@ -112,6 +113,7 @@ class PeriodictaskControllerTest < ActionController::TestCase
     assert_equal 1, task.interval_number
     assert_equal 'month', task.interval_units
     assert_equal 5, task.status_id
+    assert_equal 40, task.done_ratio
     assert_equal @project.id, task.project_id
   end
 
@@ -142,6 +144,24 @@ class PeriodictaskControllerTest < ActionController::TestCase
     get :edit, params: { project_id: 'ecookbook', id: task.id }
 
     assert_select '#periodictask_status_id option[selected="selected"][value="5"]'
+  end
+
+  def test_edit_selects_configured_done_ratio
+    task = create_test_periodictask(done_ratio: 70)
+
+    get :edit, params: { project_id: 'ecookbook', id: task.id }
+
+    assert_select '#periodictask_done_ratio option[selected="selected"][value="70"]'
+  end
+
+  def test_show_renders_done_ratio_progress_bar
+    task = create_test_periodictask(done_ratio: 70)
+
+    get :show, params: { project_id: 'ecookbook', id: task.id }
+
+    assert_response :success
+    assert_select '.progress.attribute table.progress td.closed[style*="width: 70%"]'
+    assert_select '.progress.attribute p.percent', text: '70%'
   end
 
   def test_edit_with_nil_watcher_user_ids

--- a/test/unit/periodictasks_test.rb
+++ b/test/unit/periodictasks_test.rb
@@ -138,6 +138,26 @@ class PeriodictasksTest < ActiveSupport::TestCase
     end
   end
 
+  def test_generate_issue_ignores_done_ratio_when_tracker_disables_it
+    tracker = Tracker.find(1)
+    tracker.core_fields = tracker.core_fields - ['done_ratio']
+    tracker.save!
+    task = Periodictask.create!(
+      project: @project,
+      tracker_id: 1,
+      author_id: 1,
+      subject: 'Tracker without progress',
+      done_ratio: 50,
+      interval_number: 1,
+      interval_units: 'month'
+    )
+
+    with_settings issue_done_ratio: 'issue_field' do
+      assert_not task.done_ratio_enabled?
+      assert_equal 0, task.generate_issue.done_ratio
+    end
+  end
+
   def test_done_ratio_must_be_between_0_and_100
     task = Periodictask.new(project: @project, subject: 'x', interval_number: 1, interval_units: 'month')
     task.done_ratio = 150

--- a/test/unit/periodictasks_test.rb
+++ b/test/unit/periodictasks_test.rb
@@ -106,6 +106,46 @@ class PeriodictasksTest < ActiveSupport::TestCase
     assert_equal 5, task.generate_issue.status_id
   end
 
+  def test_generate_issue_with_configured_done_ratio
+    task = Periodictask.create!(
+      project: @project,
+      tracker_id: 1,
+      author_id: 1,
+      subject: 'Half done task',
+      done_ratio: 50,
+      interval_number: 1,
+      interval_units: 'month'
+    )
+
+    with_settings issue_done_ratio: 'issue_field' do
+      assert_equal 50, task.generate_issue.done_ratio
+    end
+  end
+
+  def test_generate_issue_ignores_done_ratio_when_computed_from_status
+    task = Periodictask.create!(
+      project: @project,
+      tracker_id: 1,
+      author_id: 1,
+      subject: 'Status driven task',
+      done_ratio: 50,
+      interval_number: 1,
+      interval_units: 'month'
+    )
+
+    with_settings issue_done_ratio: 'issue_status' do
+      assert_equal 0, task.generate_issue.done_ratio
+    end
+  end
+
+  def test_done_ratio_must_be_between_0_and_100
+    task = Periodictask.new(project: @project, subject: 'x', interval_number: 1, interval_units: 'month')
+    task.done_ratio = 150
+    assert_not task.valid?
+    task.done_ratio = nil
+    assert task.valid?
+  end
+
   def test_generate_issue_with_start_date
     task = Periodictask.create!(
       project: @project,


### PR DESCRIPTION
## Summary
Replaces the disabled `% Done` placeholder in the form with a real, stored `done_ratio` (**requires migration**), copied onto generated issues and rendered on the detail page with Redmine's own `progress_bar` helper (same markup/CSS as the issue page, so no bar code is duplicated).

- `_form`: `f.select :done_ratio` with the same 0..100 step-10 options as `issues/_attributes`; blank option = "(Default) - 0 %".
- `show`: `rows.right l(:field_done_ratio), progress_bar(done_ratio.to_i, legend: "N%"), class: 'progress'` — identical to `issues/show`.
- `Periodictask#done_ratio_enabled?` = `Issue.use_field_for_done_ratio? && effective_tracker.core_fields.include?('done_ratio')`, mirroring Redmine's `safe_attribute?('done_ratio')` check on the issue form. The form field, the detail row and the copy in `generate_issue` are all gated on it, so a tracker with `% Done` disabled (or the "compute from status" setting) never exposes or applies a value. In the form the tracker options carry `data-done-ratio-enabled` and the field is toggled client-side on tracker change.
- Model validates `done_ratio` in `0..100`, nil allowed.

Verified with the docker test suite (Redmine 6.1: 123 runs, 0 failures), rubocop, and browser testing on Redmine 7.0 (see PR comment).

Link to Devin session: https://app.devin.ai/sessions/ac210409245f42afb2ccf8429f5a0786
Open in Devin Desktop: https://app.devin.ai/desktop/session/ac210409245f42afb2ccf8429f5a0786?variant=devin
Requested by: @jperelli