### PR TITLE
Localize project menu tab, module and permission names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Add configurable `subtasks` and `related issues`: each generated issue gets the configured child issues and relations **requires migration** (@jperelli)
 - Add spanish translation ([#136](https://github.com/jperelli/Redmine-Periodic-Task/pull/136)) (@lupa18)
 
+### Fixes
+
+- Localize the project menu tab, module name and permission name instead of hardcoding `Periodic Task` (@jperelli)
+
 ### Chore
 
 - Add Redmine 7.0 to the CI test matrix and bump the dev docker image to 7.0 (@jperelli)

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -11,6 +11,8 @@ bg:
   label_edit_periodic_task: Редактиране на периодична задача
   label_new_periodic_task: Нова периодична задача
   label_periodic_tasks: Периодични задачи
+  project_module_periodictask: Периодични задачи
+  permission_periodictask: Управление на периодични задачи
   label_create_periodic_task: Създаване
   label_save_periodic_task: Запис
   label_scheduled_tasks: Планирани задачи

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -11,6 +11,8 @@ de:
   label_edit_periodic_task: Wiederholende Aufgaben bearbeiten
   label_new_periodic_task: Wiederholende Aufgabe erstellen
   label_periodic_tasks: Wiederholende Aufgaben
+  project_module_periodictask: Wiederholende Aufgaben
+  permission_periodictask: Wiederholende Aufgaben verwalten
   label_create_periodic_task: Erstellen
   label_save_periodic_task: Speichern
   label_scheduled_tasks: Nachfolgend die Liste der aktiven wiederholenden Aufgaben.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,8 @@ en:
   label_edit_periodic_task: Edit Periodic Task
   label_new_periodic_task: New Periodic Task
   label_periodic_tasks: Periodic Tasks
+  project_module_periodictask: Periodic tasks
+  permission_periodictask: Manage periodic tasks
   label_periodic_task: Periodic Task
   label_create_periodic_task: Create
   label_save_periodic_task: Save

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -11,6 +11,8 @@ es:
   label_edit_periodic_task: Editar tarea periódica
   label_new_periodic_task: Nueva tarea periódica
   label_periodic_tasks: Tareas periódicas
+  project_module_periodictask: Tareas periódicas
+  permission_periodictask: Gestionar tareas periódicas
   label_periodic_task: Tarea periódica
   label_create_periodic_task: Crear
   label_save_periodic_task: Guardar

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -11,6 +11,8 @@ hr:
   label_edit_periodic_task: Uredi periodički zadatak
   label_new_periodic_task: Novi periodički zadatak
   label_periodic_tasks: Periodički zadaci
+  project_module_periodictask: Periodički zadaci
+  permission_periodictask: Upravljanje periodičkim zadacima
   label_create_periodic_task: Stvori
   label_save_periodic_task: Spremi
   label_scheduled_tasks: Trenutno zakazani zadaci

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -11,6 +11,8 @@ it:
   label_edit_periodic_task: Modifica Periodic Task
   label_new_periodic_task: Nuovo Periodic Task
   label_periodic_tasks: Periodic Tasks
+  project_module_periodictask: Attività periodiche
+  permission_periodictask: Gestisci attività periodiche
   label_create_periodic_task: Crea
   label_save_periodic_task: Salva
   label_scheduled_tasks: Attualmente non ci sono task schedulati

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,8 @@ ja:
   label_edit_periodic_task: 繰り返しチケットの編集
   label_new_periodic_task: 新規繰り返しチケット
   label_periodic_tasks: 繰り返しチケット
+  project_module_periodictask: 繰り返しチケット
+  permission_periodictask: 繰り返しチケットの管理
   label_create_periodic_task: 作成
   label_save_periodic_task: 保存
   label_scheduled_tasks: 現在、スケジュールされているタスク

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -11,6 +11,8 @@ pl:
   label_edit_periodic_task: Edytuj zadanie cykliczne
   label_new_periodic_task: Nowe zadanie cykliczne
   label_periodic_tasks: Zadania cykliczne
+  project_module_periodictask: Zadania cykliczne
+  permission_periodictask: Zarządzanie zadaniami cyklicznymi
   label_create_periodic_task: Utwórz
   label_save_periodic_task: Zapisz
   label_scheduled_tasks: Aktualnie zaplanowane zadania

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -11,6 +11,8 @@ pt-BR:
   label_edit_periodic_task: Editar tarefa periódica
   label_new_periodic_task: Nova tarefa periódica
   label_periodic_tasks: Tarefas Periódicas
+  project_module_periodictask: Tarefas periódicas
+  permission_periodictask: Gerenciar tarefas periódicas
   label_create_periodic_task: Criar
   label_save_periodic_task: Salvar
   label_scheduled_tasks: Tarefas agendadas atualmente

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -11,6 +11,8 @@ ru:
   label_edit_periodic_task: Редактировать периодическую задачу
   label_new_periodic_task: Новая периодическая задача
   label_periodic_tasks: Периодические Задачи
+  project_module_periodictask: Периодические задачи
+  permission_periodictask: Управление периодическими задачами
   label_create_periodic_task: Создать
   label_save_periodic_task: Сохранить
   label_scheduled_tasks: Запланированные задачи

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -11,6 +11,8 @@ tr:
   label_edit_periodic_task: Periyodik işi düzenle
   label_new_periodic_task: Yeni periyodik iş
   label_periodic_tasks: Periyodik İşler
+  project_module_periodictask: Periyodik işler
+  permission_periodictask: Periyodik işleri yönet
   label_create_periodic_task: Yeni
   label_save_periodic_task: Kaydet
   label_scheduled_tasks: Periyodik iş listesi

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -11,6 +11,8 @@ uk:
   label_edit_periodic_task: Редагувати періодичне завдання
   label_new_periodic_task: Нове періодичне завдання
   label_periodic_tasks: Періодичні завдання
+  project_module_periodictask: Періодичні завдання
+  permission_periodictask: Керування періодичними завданнями
   label_create_periodic_task: Створити
   label_save_periodic_task: Зберегти
   label_scheduled_tasks: Заплановані завдання

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -13,6 +13,8 @@ zh:
   label_edit_periodic_task: 编辑周期任务
   label_new_periodic_task: 新建周期任务
   label_periodic_tasks: 周期任务
+  project_module_periodictask: 周期任务
+  permission_periodictask: 管理周期任务
   label_create_periodic_task: 新建
   label_save_periodic_task: 保存
   label_scheduled_tasks: 当前计划的任务

--- a/init.rb
+++ b/init.rb
@@ -29,5 +29,5 @@ Redmine::Plugin.register :periodictask do
   activity_provider :periodictasks, class_name: 'PeriodictaskJournal'
 
   menu :project_menu, :periodictask, { controller: 'periodictask', action: 'index' },
-       caption: 'Periodic Task', after: :settings, param: :project_id
+       caption: :label_periodic_tasks, after: :settings, param: :project_id
 end


### PR DESCRIPTION
## Summary
Found while UI-testing the Spanish locale (#146): with the UI in Spanish the project tab still read "Periodic Task" and the module checkbox "Periodictask", because `init.rb` hardcoded the menu caption and no locale defined the Redmine-conventional `project_module_<name>` / `permission_<name>` keys.

```diff
-  menu :project_menu, :periodictask, {...}, caption: 'Periodic Task', ...
+  menu :project_menu, :periodictask, {...}, caption: :label_periodic_tasks, ...
```

Every locale (`bg de en es hr it ja pl pt-BR ru tr uk zh`) gains `project_module_periodictask` and `permission_periodictask`, reusing each file's existing "Periodic tasks" wording. Net effect in English: tab "Periodic Tasks" (was "Periodic Task"), module "Periodic tasks" (was "Periodictask"), permission "Manage periodic tasks" (was "Periodictask").

Link to Devin session: https://app.devin.ai/sessions/278cfff4fca44078af052b7182ac429b
Open in Devin Desktop: https://app.devin.ai/desktop/session/278cfff4fca44078af052b7182ac429b?variant=devin
Requested by: @jperelli