### PR TITLE
Add shifted date macros and their year companions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Apply the `Project` patch (`has_many :periodictasks, dependent: :destroy`) at plugin load; the nested `to_prepare` it used never ran outside code reloading (@jperelli)
 - `business day` intervals keep the scheduled time of day and no longer skip a day: the next run used to be moved to the start of the business day (09:00) whenever the task was scheduled outside business hours ([#79](https://github.com/jperelli/Redmine-Periodic-Task/issues/79), idea from [chris85618's fork](https://github.com/chris85618/Redmine-Periodic-Task))
+- A shifted month or an ISO week can now render a consistent year: `**PREVIOUS_MONTH**`/`**YEAR**` rendered `12/2026` when run in January 2026, and `**WEEKISO**`/`**YEAR**` was off by one around New Year
 
 ## v7.0.0 - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add an `Administration` > `Periodic Tasks` page listing the tasks of every project, inspired by [@rkteam](https://github.com/rkteam)'s fork (@jperelli)
 - Add a `Copy` action that opens the new task form prefilled from an existing task, inspired by [@vegaminer](https://github.com/vegaminer)'s fork (@jperelli)
 - Add Vietnamese (`vi`) translation, adapted from [@tq89](https://github.com/tq89)'s fork (@jperelli)
-
+- Add the shifted date macros `**NEXT_MONTH**`, `**NEXT_MONTHNAME**`, `**NEXT_WEEK**`, `**NEXT_WEEKISO**` and the year companions `**NEXT_MONTH_YEAR**`, `**NEXT_WEEK_YEAR**`, `**NEXT_WEEKISO_YEAR**`, `**PREVIOUS_MONTH_YEAR**`, `**WEEKISO_YEAR**` (idea and implementation from [tq89's fork](https://github.com/tq89/Redmine-Periodic-Task))
 ### Fixes
 
 - Apply the `Project` patch (`has_many :periodictasks, dependent: :destroy`) at plugin load; the nested `to_prepare` it used never ran outside code reloading (@jperelli)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add a `Copy` action that opens the new task form prefilled from an existing task, inspired by [@vegaminer](https://github.com/vegaminer)'s fork (@jperelli)
 - Add Vietnamese (`vi`) translation, adapted from [@tq89](https://github.com/tq89)'s fork (@jperelli)
 - Add the shifted date macros `**NEXT_MONTH**`, `**NEXT_MONTHNAME**`, `**NEXT_WEEK**`, `**NEXT_WEEKISO**` and the year companions `**NEXT_MONTH_YEAR**`, `**NEXT_WEEK_YEAR**`, `**NEXT_WEEKISO_YEAR**`, `**PREVIOUS_MONTH_YEAR**`, `**WEEKISO_YEAR**` (idea and implementation from [tq89's fork](https://github.com/tq89/Redmine-Periodic-Task))
+
 ### Fixes
 
 - Apply the `Project` patch (`has_many :periodictasks, dependent: :destroy`) at plugin load; the nested `to_prepare` it used never ran outside code reloading (@jperelli)

--- a/README.md
+++ b/README.md
@@ -193,13 +193,27 @@ You can use the following variables in the subject and description of a periodic
 |---|---|
 | `**DAY**` | Day of the month, zero-padded (01..31) |
 | `**WEEK**` | Week number of the year, starting with the first Monday as the first day of the first week (00..53) |
+| `**NEXT_WEEK**` | Same as `**WEEK**` for next week (00..53) |
 | `**WEEKISO**` | ISO 8601 week number of the year (01..53) |
+| `**NEXT_WEEKISO**` | Same as `**WEEKISO**` for next week (01..53) |
 | `**MONTH**` | Month of the year, zero-padded (01..12) |
+| `**PREVIOUS_MONTH**` | Previous month, zero-padded (01..12) |
+| `**NEXT_MONTH**` | Next month, zero-padded (01..12) |
 | `**MONTHNAME**` | Full month name (e.g. January), localized |
+| `**PREVIOUS_MONTHNAME**` | Full name of the previous month, localized |
+| `**NEXT_MONTHNAME**` | Full name of the next month, localized |
 | `**QUARTER**` | Quarter of the year (1..4) |
 | `**YEAR**` | Four-digit year |
-| `**PREVIOUS_MONTH**` | Previous month, zero-padded (01..12) |
-| `**PREVIOUS_MONTHNAME**` | Full name of the previous month, localized |
+| `**WEEKISO_YEAR**` | ISO 8601 week-based year of `**WEEKISO**` |
+| `**NEXT_WEEK_YEAR**` | Four-digit year of `**NEXT_WEEK**` |
+| `**NEXT_WEEKISO_YEAR**` | ISO 8601 week-based year of `**NEXT_WEEKISO**` |
+| `**PREVIOUS_MONTH_YEAR**` | Four-digit year of `**PREVIOUS_MONTH**` |
+| `**NEXT_MONTH_YEAR**` | Four-digit year of `**NEXT_MONTH**` |
+
+Each shifted macro has its own year companion, and `**WEEKISO**` has a week-based one, because the year of the
+shifted instant is not always the year of the run: pairing `**PREVIOUS_MONTH**` with `**YEAR**` yields `12/2026`
+when it runs in January 2026, and an ISO week number belongs to the ISO week-based year, which differs from the
+calendar year around New Year (2025-12-29 is already ISO week 01 of 2026).
 
 If you want to get localized month names, please add `LOCALE="de"` (available are `bg`, `de`, `en`, `es`, `hr`, `it`, `ja`, `pl`, `pt-BR`, `ru`, `tr`, `uk`, `vi`, `zh`) to the cronjob like this
 

--- a/app/models/periodictask.rb
+++ b/app/models/periodictask.rb
@@ -456,15 +456,32 @@ class Periodictask < ActiveRecord::Base
   def parse_macro(str, now)
     if str.respond_to?(:gsub!) && str.present?
       previous_month_time = now - 1.month
+      next_month_time = now + 1.month
+      next_week_time = now + 1.week
       str.gsub!('**DAY**', now.strftime('%d'))
+      # The two week numbering systems do not share a year macro: %W counts weeks
+      # within the calendar year and pairs with %Y, while %V counts ISO 8601 weeks
+      # and pairs with the ISO year %G. The two drift apart around New Year, so
+      # pairing an ISO week with **YEAR** is off by one on those dates.
+      str.gsub!('**NEXT_WEEKISO_YEAR**', next_week_time.strftime('%G'))
+      str.gsub!('**NEXT_WEEKISO**', next_week_time.strftime('%V'))
+      str.gsub!('**NEXT_WEEK_YEAR**', next_week_time.strftime('%Y'))
+      str.gsub!('**NEXT_WEEK**', next_week_time.strftime('%W'))
+      str.gsub!('**WEEKISO_YEAR**', now.strftime('%G'))
       str.gsub!('**WEEKISO**', now.strftime('%V'))
       str.gsub!('**WEEK**', now.strftime('%W'))
       str.gsub!('**QUARTER**', (((now.month - 1) / 3) + 1).to_s)
       str.gsub!('**MONTHNAME**', I18n.localize(now, format: '%B'))
       str.gsub!('**MONTH**', now.strftime('%m'))
+      # Year of the shifted month, not of the run time: **YEAR** next to a shifted
+      # month macro is off by one in January and December.
+      str.gsub!('**NEXT_MONTH_YEAR**', next_month_time.strftime('%Y'))
+      str.gsub!('**PREVIOUS_MONTH_YEAR**', previous_month_time.strftime('%Y'))
       str.gsub!('**YEAR**', now.strftime('%Y'))
       str.gsub!('**PREVIOUS_MONTHNAME**', I18n.localize(previous_month_time, format: '%B'))
       str.gsub!('**PREVIOUS_MONTH**', previous_month_time.strftime('%m'))
+      str.gsub!('**NEXT_MONTHNAME**', I18n.localize(next_month_time, format: '%B'))
+      str.gsub!('**NEXT_MONTH**', next_month_time.strftime('%m'))
     end
     str
   end

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -38,13 +38,22 @@ bg:
     Възможни променливи:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (Януари - Декември)
     **PREVIOUS_MONTHNAME** (Януари - Декември)
+    **NEXT_MONTHNAME** (Януари - Декември)
   label_variables_markdown_note: 'Забележка: в описанието те се показват получер в прегледа, тъй като ** е синтаксисът за получер текст в Markdown; при създаване на задачата се заменят с действителната стойност.'
   label_last_error: Последна грешка
   label_issue_custom_fields: Потребителски полета на задачата

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -38,13 +38,22 @@ de:
     Mögliche Variablen:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (Januar - Dezember)
     **PREVIOUS_MONTHNAME** (Januar - Dezember)
+    **NEXT_MONTHNAME** (Januar - Dezember)
   label_variables_markdown_note: 'Hinweis: In der Beschreibung erscheinen diese in der Vorschau fett, da ** die Fett-Syntax von Markdown ist; sie werden beim Erstellen der Aufgabe durch den tatsächlichen Wert ersetzt.'
   label_last_error: Letzter Fehler
   label_issue_custom_fields: Benutzerdefinierte Felder

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,13 +58,22 @@ en:
     Possible variables:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (January - December)
     **PREVIOUS_MONTHNAME** (January - December)
+    **NEXT_MONTHNAME** (January - December)
   label_variables_markdown_note: 'Note: in the description these appear in bold in the preview because ** is Markdown''s bold syntax; they are replaced with the actual value when the issue is created.'
   label_last_error: Last error
   label_issue_custom_fields: Issue custom fields

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -44,13 +44,22 @@ es:
     Variables disponibles:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (AAAA)
+    **WEEKISO_YEAR** (AAAA)
+    **NEXT_WEEK_YEAR** (AAAA)
+    **NEXT_WEEKISO_YEAR** (AAAA)
+    **PREVIOUS_MONTH_YEAR** (AAAA)
+    **NEXT_MONTH_YEAR** (AAAA)
     **MONTHNAME** (Enero - Diciembre)
     **PREVIOUS_MONTHNAME** (Enero - Diciembre)
+    **NEXT_MONTHNAME** (Enero - Diciembre)
   label_variables_markdown_note: 'Nota: en la descripción, estas variables aparecen en negrita en la vista previa porque ** es la sintaxis de negrita de Markdown; se reemplazan por el valor real cuando se crea la incidencia.'
   label_last_error: Último error
   label_issue_custom_fields: Campos personalizados de la incidencia

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -38,13 +38,22 @@ hr:
     Moguće varijable:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (Siječanj - Prosinac)
     **PREVIOUS_MONTHNAME** (Siječanj - Prosinac)
+    **NEXT_MONTHNAME** (Siječanj - Prosinac)
   label_variables_markdown_note: 'Napomena: u opisu se u pregledu prikazuju podebljano jer je ** Markdown sintaksa za podebljani tekst; zamjenjuju se stvarnom vrijednošću pri kreiranju zadatka.'
   label_last_error: Zadnja greška
   label_issue_custom_fields: Prilagođena polja

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -38,13 +38,22 @@ it:
     I possibili valori:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (Gennaio - Dicembre)
     **PREVIOUS_MONTHNAME** (Gennaio - Dicembre)
+    **NEXT_MONTHNAME** (Gennaio - Dicembre)
   label_variables_markdown_note: 'Nota: nella descrizione appaiono in grassetto nell''anteprima perché ** è la sintassi del grassetto di Markdown; vengono sostituite con il valore effettivo quando la richiesta viene creata.'
   label_last_error: Ultimo errore
   label_issue_custom_fields: Campi personalizzati

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -38,13 +38,22 @@ ja:
     利用可能な変数:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (January - December)
     **PREVIOUS_MONTHNAME** (January - December)
+    **NEXT_MONTHNAME** (January - December)
   label_variables_markdown_note: '注: 説明欄では ** が Markdown の太字記法であるため、プレビューでは太字で表示されますが、チケット作成時に実際の値に置き換えられます。'
   label_last_error: 最後のエラー
   label_issue_custom_fields: カスタムフィールド

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -38,13 +38,22 @@ pl:
     Dostępne zmienne:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (Styczeń - Grudzień)
     **PREVIOUS_MONTHNAME** (Styczeń - Grudzień)
+    **NEXT_MONTHNAME** (Styczeń - Grudzień)
   label_variables_markdown_note: 'Uwaga: w opisie są one wyświetlane pogrubioną czcionką w podglądzie, ponieważ ** to składnia pogrubienia w Markdown; przy tworzeniu zadania są zastępowane rzeczywistą wartością.'
   label_last_error: Ostatni błąd
   label_issue_custom_fields: Pola niestandardowe

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -38,13 +38,22 @@ pt-BR:
     Variáveis possíveis:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (Janeiro - Dezembro)
     **PREVIOUS_MONTHNAME** (Janeiro - Dezembro)
+    **NEXT_MONTHNAME** (Janeiro - Dezembro)
   label_variables_markdown_note: 'Observação: na descrição elas aparecem em negrito na pré-visualização porque ** é a sintaxe de negrito do Markdown; são substituídas pelo valor real quando a tarefa é criada.'
   label_last_error: Último erro
   label_issue_custom_fields: Campos personalizados

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -38,13 +38,22 @@ ru:
     Возможные переменные:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (Январь - Декабрь)
     **PREVIOUS_MONTHNAME** (Январь - Декабрь)
+    **NEXT_MONTHNAME** (Январь - Декабрь)
   label_variables_markdown_note: 'Примечание: в описании они отображаются полужирным в предпросмотре, так как ** — это синтаксис полужирного начертания в Markdown; при создании задачи они заменяются фактическим значением.'
   label_last_error: Последняя ошибка
   label_issue_custom_fields: Настраиваемые поля задачи

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -38,13 +38,22 @@ tr:
     Kullanılabilir makrolar:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (Ocak - Aralık)
     **PREVIOUS_MONTHNAME** (Ocak - Aralık)
+    **NEXT_MONTHNAME** (Ocak - Aralık)
   label_variables_markdown_note: 'Not: açıklamada önizlemede kalın görünürler çünkü ** Markdown''ın kalın yazı söz dizimidir; iş kaydı oluşturulduğunda gerçek değerleriyle değiştirilirler.'
   label_last_error: Son hata
   label_issue_custom_fields: Özel alanlar

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -38,13 +38,22 @@ uk:
     Можливі змінні:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (Січень - Грудень)
     **PREVIOUS_MONTHNAME** (Січень - Грудень)
+    **NEXT_MONTHNAME** (Січень - Грудень)
   label_variables_markdown_note: 'Примітка: в описі вони відображаються жирним у попередньому перегляді, оскільки ** — це синтаксис жирного шрифту в Markdown; під час створення завдання вони замінюються фактичним значенням.'
   label_last_error: Остання помилка
   label_issue_custom_fields: Налаштовувані поля завдання

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -60,13 +60,22 @@ vi:
     Các biến có thể dùng:
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (tên tháng)
     **PREVIOUS_MONTHNAME** (tên tháng trước)
+    **NEXT_MONTHNAME** (tên tháng sau)
   label_variables_markdown_note: 'Lưu ý: ở phần mô tả, các biến này hiện đậm trong khung xem trước vì ** là cú pháp in đậm của Markdown; chúng sẽ được thay bằng giá trị thật khi vấn đề được tạo.'
   label_last_error: Lỗi gần nhất
   label_issue_custom_fields: Trường tùy chỉnh của vấn đề

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -43,13 +43,22 @@ zh-TW:
     可選值：
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (一月 - 十二月)
     **PREVIOUS_MONTHNAME** (一月 - 十二月)
+    **NEXT_MONTHNAME** (一月 - 十二月)
   label_variables_markdown_note: '注意：在概述中，由於 ** 是 Markdown 的粗體語法，它們在預覽中會顯示為粗體；建立議題時會替換為實際值。'
   label_last_error: 最後錯誤
   label_issue_custom_fields: 自訂欄位

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -40,13 +40,22 @@ zh:
     可选值：
     **DAY** (01-31)
     **WEEK** (00-53)
+    **NEXT_WEEK** (00-53)
     **WEEKISO** (01-53)
+    **NEXT_WEEKISO** (01-53)
     **MONTH** (01-12)
     **PREVIOUS_MONTH** (01-12)
+    **NEXT_MONTH** (01-12)
     **QUARTER** (1-4)
     **YEAR** (YYYY)
+    **WEEKISO_YEAR** (YYYY)
+    **NEXT_WEEK_YEAR** (YYYY)
+    **NEXT_WEEKISO_YEAR** (YYYY)
+    **PREVIOUS_MONTH_YEAR** (YYYY)
+    **NEXT_MONTH_YEAR** (YYYY)
     **MONTHNAME** (一月 - 十二月)
     **PREVIOUS_MONTHNAME** (一月 - 十二月)
+    **NEXT_MONTHNAME** (一月 - 十二月)
   label_variables_markdown_note: '注意：在描述中，由于 ** 是 Markdown 的加粗语法，它们在预览中显示为加粗；创建问题时会替换为实际值。'
   label_last_error: 最后错误
   label_issue_custom_fields: 自定义字段

--- a/test/unit/periodictasks_test.rb
+++ b/test/unit/periodictasks_test.rb
@@ -653,6 +653,49 @@ class PeriodictasksTest < ActiveSupport::TestCase
     assert_equal "Q3 W#{now.strftime('%V')} 06", issue.description
   end
 
+  def test_macro_shifted_month_and_week
+    now = Time.utc(2026, 7, 20, 10, 0, 0)
+    str = parse_macro(
+      'M**MONTH** P**PREVIOUS_MONTH** N**NEXT_MONTH** W**WEEK** NW**NEXT_WEEK** I**WEEKISO** NI**NEXT_WEEKISO**',
+      now
+    )
+    next_week = now + 1.week
+    assert_equal "M07 P06 N08 W#{now.strftime('%W')} NW#{next_week.strftime('%W')} " \
+                 "I#{now.strftime('%V')} NI#{next_week.strftime('%V')}", str
+  end
+
+  def test_macro_next_monthname
+    now = Time.utc(2026, 12, 20, 10, 0, 0)
+    assert_equal 'January', parse_macro('**NEXT_MONTHNAME**', now)
+  end
+
+  # **YEAR** is the year of the run, so a shifted month needs its own year macro
+  # to stay consistent across a year boundary.
+  def test_macro_shifted_month_year_across_year_boundary
+    assert_equal '12/2025',
+                 parse_macro('**PREVIOUS_MONTH**/**PREVIOUS_MONTH_YEAR**', Time.utc(2026, 1, 15, 10, 0, 0))
+    assert_equal '01/2027',
+                 parse_macro('**NEXT_MONTH**/**NEXT_MONTH_YEAR**', Time.utc(2026, 12, 15, 10, 0, 0))
+  end
+
+  # An ISO week number belongs to the ISO week-based year, which drifts from the
+  # calendar year around New Year in both directions.
+  def test_macro_weekiso_year_follows_iso_year
+    assert_equal '01/2026',
+                 parse_macro('**WEEKISO**/**WEEKISO_YEAR**', Time.utc(2025, 12, 29, 10, 0, 0))
+    assert_equal '53/2026',
+                 parse_macro('**WEEKISO**/**WEEKISO_YEAR**', Time.utc(2027, 1, 1, 10, 0, 0))
+    assert_equal '53/2026',
+                 parse_macro('**NEXT_WEEKISO**/**NEXT_WEEKISO_YEAR**', Time.utc(2026, 12, 25, 10, 0, 0))
+    # %W numbers weeks from the first Monday, so 2027-01-01 (a Friday) is week 00
+    assert_equal '00/2027',
+                 parse_macro('**NEXT_WEEK**/**NEXT_WEEK_YEAR**', Time.utc(2026, 12, 25, 10, 0, 0))
+  end
+
+  def parse_macro(str, now)
+    Periodictask.new.send(:parse_macro, str.dup, now)
+  end
+
   def test_fill_custom_fields_assigns_hash_loaded_from_db
     task = Periodictask.new(custom_field_values: { 10 => 'Stored value' })
     issue = Struct.new(:custom_field_values).new


### PR DESCRIPTION
## Summary

Adds the `**NEXT_*` counterparts to the existing shifted-date macros and, more importantly, gives every shifted macro its own year macro. Idea and original implementation from [tq89's fork](https://github.com/tq89/Redmine-Periodic-Task).

New macros: `**NEXT_MONTH**`, `**NEXT_MONTHNAME**`, `**NEXT_WEEK**`, `**NEXT_WEEKISO**`, `**NEXT_MONTH_YEAR**`, `**NEXT_WEEK_YEAR**`, `**NEXT_WEEKISO_YEAR**`, `**PREVIOUS_MONTH_YEAR**`, `**WEEKISO_YEAR**`.

The year macros fix two real off-by-one-year subjects, which today have no correct workaround:

- `**PREVIOUS_MONTH**/**YEAR**` run in January 2026 renders `12/2026`; with `**PREVIOUS_MONTH_YEAR**` it renders `12/2025`.
- `**WEEKISO**` is an ISO 8601 week (`%V`), which belongs to the ISO week-based year (`%G`), not the calendar year (`%Y`). On 2025-12-29 `**WEEKISO**/**YEAR**` renders `01/2025` instead of `01/2026`.

Substitution order matters, since replacement is plain `gsub!` on a shared string: longer names are substituted before names that are a prefix of them, e.g. `**NEXT_WEEKISO_YEAR**` and `**NEXT_WEEKISO**` before `**NEXT_WEEK**`, and `**PREVIOUS_MONTH_YEAR**` before `**YEAR**`.

Also updates the in-form variable help text in all 15 locales, the README table, and the CHANGELOG. Tests cover the new macros and both year-boundary cases.

## Screenshot

Generated issue showing `**NEXT_MONTH**`/`**NEXT_MONTH_YEAR**`, `**PREVIOUS_MONTH**`/`**PREVIOUS_MONTH_YEAR**` and `**NEXT_WEEKISO**`/`**NEXT_WEEKISO_YEAR**` substituted:

![Generated issue showing `**NEXT_MONTH**`/`**NEXT_MONTH_YEAR**`, `**PREVIOUS_MONTH**`/`**PREVIOUS_MONTH_YEAR**` and `**NEXT_WEEKISO**`/`**NEXT_WEEKISO_YEAR**` substituted](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctYzIwOWY1ZWJjNTQ2NGUxODhkMjg4M2VhYjA3YjQ2N2YiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctYzIwOWY1ZWJjNTQ2NGUxODhkMjg4M2VhYjA3YjQ2N2YvZjI3NDk5NjEtMThjYS00N2Y4LWFhMDUtODNmMWU4OTJhYzg5IiwiaWF0IjoxNzg4NjI5OTEwLCJleHAiOjE3ODkyMzQ3MTAsImZpbGVuYW1lIjoicHIxNTMtc2hpZnRlZC1kYXRlLW1hY3Jvcy5wbmcifQ.XYPkYlmrpQ5JSWYxWr42GVHZn5i4s7cqbwFLmWHAMzg)


Link to Devin session: https://app.devin.ai/sessions/3fb539ab13694d6a82edab4fd1e9a863
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fb539ab13694d6a82edab4fd1e9a863?variant=devin
Requested by: @jperelli