### PR TITLE
Keep the scheduled time of day for business day intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixes
 
 - Apply the `Project` patch (`has_many :periodictasks, dependent: :destroy`) at plugin load; the nested `to_prepare` it used never ran outside code reloading (@jperelli)
+- `business day` intervals keep the scheduled time of day and no longer skip a day: the next run used to be moved to the start of the business day (09:00) whenever the task was scheduled outside business hours ([#79](https://github.com/jperelli/Redmine-Periodic-Task/issues/79), idea from [chris85618's fork](https://github.com/chris85618/Redmine-Periodic-Task))
 
 ## v7.0.0 - 2026-09-03
 

--- a/app/models/periodictask.rb
+++ b/app/models/periodictask.rb
@@ -346,7 +346,7 @@ class Periodictask < ActiveRecord::Base
     units = interval_units.downcase
     val = next_run_date || now
     if units == 'business_day'
-      val = interval_number.business_day.after(val) while val <= now
+      val = next_business_day_occurrence(val, now)
     elsif units == 'week' && weekdays.any?
       val = next_weekday_occurrence(val, now)
     elsif monthly_weekday_mode? && weekdays.any? && month_weeks.any?
@@ -359,6 +359,20 @@ class Periodictask < ActiveRecord::Base
   end
 
   private
+
+  # Walks business days from the anchor's date and keeps the anchor's time of
+  # day. business_time counts from the instant, so feeding it a time outside
+  # business hours would move the occurrence to the start of a business day
+  # (09:00 by default) and lose the scheduled time.
+  def next_business_day_occurrence(anchor, now)
+    date = anchor.to_date
+    val = anchor
+    while val <= now
+      date = interval_number.business_days.after(date)
+      val = at_anchor_time(date, anchor)
+    end
+    val
+  end
 
   # Walks the eligible weeks (every interval_number weeks from the anchor's
   # week) and returns the first selected weekday, at the anchor's time of day,

--- a/doc/recurrence-design.md
+++ b/doc/recurrence-design.md
@@ -32,7 +32,7 @@ week to day does not keep its old weekdays.
 ```
 get_next_run_date(now):
   anchor = next_run_date || now
-  business_day                                  -> add N business days to the anchor until the result is after now
+  business_day                                  -> next_business_day_occurrence
   week, with weekdays selected                  -> next_weekday_occurrence
   month, monthly_mode == weekday,
         with weekdays and month_weeks selected  -> next_monthly_weekday_occurrence
@@ -44,6 +44,18 @@ has empty `weekdays` and `month_weeks`, so it keeps using this rule and runs
 as before. The same rule handles the monthly day-of-month mode: the day is
 the day of the anchor. Google Calendar works the same way, "Monthly on day
 15" comes from the start date and there is no separate field for it.
+
+## Business days
+
+Example: every 3 business days.
+
+Only the date is walked: N business days are added to the date of the anchor
+until the result is after now, and the time of day of the anchor is kept. The
+`business_time` gem counts from an instant, so counting from the anchor itself
+would move a task scheduled outside business hours to the start of a business
+day (09:00 by default) and, for an evening task, skip the next day: 20:30 on a
+Monday first rolls forward to Tuesday 09:00 and then adds the interval.
+Weekends and the gem's holidays are skipped either way.
 
 ## Weekly, on selected weekdays
 

--- a/test/unit/get_next_run_date_test.rb
+++ b/test/unit/get_next_run_date_test.rb
@@ -17,7 +17,11 @@ GetNextRunDateTestTask = Struct.new(:next_run_date, :interval_number, :interval_
     units = interval_units.downcase
     val = next_run_date || now
     if units == 'business_day'
-      val = interval_number.business_day.after(val) while val <= now
+      date = val.to_date
+      while val <= now
+        date = interval_number.business_days.after(date)
+        val = val.change(year: date.year, month: date.month, day: date.day)
+      end
     else
       interval_steps = ((now - val) / interval_number.send(units)).ceil
       val += (interval_number * interval_steps).send(units)
@@ -73,10 +77,10 @@ class GetNextRunDateTest < Minitest::Test
     end
   end
 
-  # For times outside business hours, business_time snaps to start of business
-  # day (09:00). Verify that once snapped, the time stays consistent and doesn't
-  # drift further. This is the exact scenario from issue #79 (user sets 06:00).
-  def test_business_day_outside_business_hours_stabilizes
+  # A schedule outside business hours keeps its time of day: only the date is
+  # walked over business days. This is the exact scenario from issue #79 (user
+  # sets 06:00), where the run used to be moved to 09:00.
+  def test_business_day_outside_business_hours_keeps_time_of_day
     # Task originally at 06:00 (before business hours)
     scheduled_time = Time.utc(2026, 4, 6, 6, 0, 0) # Monday 06:00
     task = GetNextRunDateTestTask.new(scheduled_time, 1, 'business_day')
@@ -84,25 +88,44 @@ class GetNextRunDateTest < Minitest::Test
     # First run: cron at 07:05
     execution_time = Time.utc(2026, 4, 6, 7, 5, 0)
     next_date = task.get_next_run_date(execution_time)
-    # business_time snaps to 09:00 (start of business day)
-    assert_equal 9, next_date.hour
-    assert_equal 0, next_date.min
-    assert next_date > execution_time
+    assert_equal Time.utc(2026, 4, 7, 6, 0, 0), next_date
 
-    # Simulate subsequent runs - time should stay at 09:00
+    # Simulate subsequent runs - time should stay at 06:00
     task.next_run_date = next_date
     3.times do |i|
       execution_time = task.next_run_date + 1800 + rand(300) # 30-35 min late
       next_date = task.get_next_run_date(execution_time)
 
-      assert_equal 9, next_date.hour,
-                   "Run #{i + 2}: Expected hour 09:00 (stable), got #{next_date.strftime('%H:%M')}"
+      assert_equal 6, next_date.hour,
+                   "Run #{i + 2}: Expected hour 06:00 (stable), got #{next_date.strftime('%H:%M')}"
       assert_equal 0, next_date.min,
                    "Run #{i + 2}: Expected minute 00, got #{next_date.strftime('%H:%M')}"
       assert next_date > execution_time
 
       task.next_run_date = next_date
     end
+  end
+
+  # An evening schedule must land on the very next business day, not skip one:
+  # counting business days from an after-hours instant first rolls forward to
+  # the next business morning and then adds the interval.
+  def test_business_day_evening_schedule_does_not_skip_a_day
+    scheduled_time = Time.utc(2026, 4, 6, 20, 30, 0) # Monday 20:30
+    task = GetNextRunDateTestTask.new(scheduled_time, 1, 'business_day')
+
+    next_date = task.get_next_run_date(Time.utc(2026, 4, 6, 20, 35, 0))
+
+    assert_equal Time.utc(2026, 4, 7, 20, 30, 0), next_date
+  end
+
+  # Weekends are still skipped when walking dates.
+  def test_business_day_skips_weekend
+    scheduled_time = Time.utc(2026, 4, 10, 20, 30, 0) # Friday 20:30
+    task = GetNextRunDateTestTask.new(scheduled_time, 1, 'business_day')
+
+    next_date = task.get_next_run_date(Time.utc(2026, 4, 10, 20, 35, 0))
+
+    assert_equal Time.utc(2026, 4, 13, 20, 30, 0), next_date # Monday
   end
 
   # Verify business_day with interval > 1

--- a/test/unit/periodictasks_test.rb
+++ b/test/unit/periodictasks_test.rb
@@ -321,6 +321,26 @@ class PeriodictasksTest < ActiveSupport::TestCase
     assert_equal scheduled + 1.day, next_date
   end
 
+  def test_get_next_run_date_business_day_keeps_time_of_day
+    scheduled = Time.utc(2026, 4, 6, 20, 30, 0) # Monday, outside business hours
+    task = Periodictask.new(
+      interval_number: 1,
+      interval_units: 'business_day',
+      next_run_date: scheduled
+    )
+    assert_equal Time.utc(2026, 4, 7, 20, 30, 0), task.get_next_run_date(scheduled + 5.minutes)
+  end
+
+  def test_get_next_run_date_business_day_skips_weekend
+    scheduled = Time.utc(2026, 4, 10, 20, 30, 0) # Friday
+    task = Periodictask.new(
+      interval_number: 1,
+      interval_units: 'business_day',
+      next_run_date: scheduled
+    )
+    assert_equal Time.utc(2026, 4, 13, 20, 30, 0), task.get_next_run_date(scheduled + 5.minutes)
+  end
+
   def test_get_next_run_date_yearly
     scheduled = Time.utc(2026, 1, 1, 10, 0, 0)
     now = scheduled + 1.hour

--- a/test/unit/timezone_test.rb
+++ b/test/unit/timezone_test.rb
@@ -18,7 +18,11 @@ TimezoneTestTask = Struct.new(:next_run_date, :interval_number, :interval_units)
     units = interval_units.downcase
     val = next_run_date || now
     if units == 'business_day'
-      val = interval_number.business_day.after(val) while val <= now
+      date = val.to_date
+      while val <= now
+        date = interval_number.business_days.after(date)
+        val = val.change(year: date.year, month: date.month, day: date.day)
+      end
     else
       interval_steps = ((now - val) / interval_number.send(units)).ceil
       val += (interval_number * interval_steps).send(units)


### PR DESCRIPTION
## Summary

A `business day` task scheduled outside business hours never runs at its own time: `business_time` counts from an *instant*, so it first rolls the anchor forward to the start of a business day and then adds the interval. A daily business-day task at 20:30 on Monday became **Wednesday 09:00** — both the time of day and one whole day were lost, and from then on it stayed at 09:00.

Fix: walk *dates* and keep the anchor's time of day, the same way `next_weekday_occurrence` already does via `at_anchor_time`.

```ruby
# before
val = interval_number.business_day.after(val) while val <= now   # 2026-04-06 20:30 -> 2026-04-08 09:00

# after
date = anchor.to_date
while val <= now
  date = interval_number.business_days.after(date)               # Date arithmetic, no business hours
  val = at_anchor_time(date, anchor)                             # 2026-04-06 20:30 -> 2026-04-07 20:30
end
```

Weekends and `business_time`'s holidays are still skipped, since the date arithmetic goes through the same gem.

Idea from [chris85618's fork](https://github.com/chris85618/Redmine-Periodic-Task), which preserved `hour/min/sec` after the fact; walking dates instead also fixes the skipped day.

`test_business_day_outside_business_hours_stabilizes` asserted the old 09:00 snapping (it only checked that the snapped time was *stable*); it is renamed and now asserts the scheduled 06:00 is kept. The two standalone tests duplicate `get_next_run_date` in a struct, so the same change is mirrored there. Also documents the rule in `doc/recurrence-design.md`.

## Screenshot

A business-day task scheduled for Friday 20:30 UTC advanced to Monday 20:30 UTC after the scheduler ran:

![A business-day task scheduled for Friday 20:30 UTC advanced to Monday 20:30 UTC after the scheduler ran](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctYzIwOWY1ZWJjNTQ2NGUxODhkMjg4M2VhYjA3YjQ2N2YiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctYzIwOWY1ZWJjNTQ2NGUxODhkMjg4M2VhYjA3YjQ2N2YvMjcxY2E0NDMtOWE4Mi00NzU3LWFkOWMtOWE0NTMxNDNlYTZmIiwiaWF0IjoxNzg4NjI5OTA5LCJleHAiOjE3ODkyMzQ3MDksImZpbGVuYW1lIjoicHIxNTUtYnVzaW5lc3MtZGF5LXRpbWUucG5nIn0.MeL6VIMtq2pM8RpfLddJ4PlWl0UArY9o4zjpJnlGXOA)


Link to Devin session: https://app.devin.ai/sessions/3fb539ab13694d6a82edab4fd1e9a863
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fb539ab13694d6a82edab4fd1e9a863?variant=devin
Requested by: @jperelli