### PR TITLE
Cover NULL json columns and document why they have no schema default

### DIFF
--- a/app/models/periodictask.rb
+++ b/app/models/periodictask.rb
@@ -9,6 +9,9 @@ class Periodictask < ActiveRecord::Base
   belongs_to :issue_category, class_name: 'IssueCategory', foreign_key: 'issue_category_id'
   has_many :periodictask_issues, dependent: :delete_all
   has_many :issues, through: :periodictask_issues
+  # The json columns default here rather than in the schema: MySQL does not
+  # accept a default on a json column, so the stored value can be NULL and the
+  # readers below normalize it.
   attribute :custom_field_values, :json
   attribute :watcher_user_ids, :json, default: []
   attribute :subtasks, :json, default: []

--- a/test/unit/periodictasks_test.rb
+++ b/test/unit/periodictasks_test.rb
@@ -730,6 +730,33 @@ class PeriodictasksTest < ActiveSupport::TestCase
     assert_equal [], task.watcher_user_ids
   end
 
+  # The json columns have no database default (MySQL rejects a default on a
+  # json column), so a row written outside the model - an old row, a raw
+  # update, another plugin - can hold NULL and every reader must cope.
+  def test_json_columns_handle_persisted_nil
+    task = Periodictask.create!(
+      project: @project,
+      tracker_id: 1,
+      author_id: 1,
+      subject: 'Nil json columns test',
+      interval_number: 1,
+      interval_units: 'week',
+      subtasks: [{ 'subject' => 'child' }],
+      relations: [{ 'relation_type' => 'relates', 'issue_id' => '1' }],
+      weekdays: [1],
+      month_weeks: [1]
+    )
+    %i[subtasks relations weekdays month_weeks].each { |column| task.update_column(column, nil) }
+    task.reload
+
+    assert_equal [], task.subtasks
+    assert_equal [], task.relations
+    assert_equal [], task.weekdays
+    assert_equal [], task.month_weeks
+    assert_nothing_raised { task.get_next_run_date(Time.current) }
+    assert_nothing_raised { task.generate_issue(Time.current) }
+  end
+
   def test_periodictask_stores_watcher_user_ids
     task = Periodictask.create!(
       project: @project,


### PR DESCRIPTION
## Summary

[chris85618's fork](https://github.com/chris85618/Redmine-Periodic-Task) changed the watcher migration to

```ruby
add_column :periodictasks, :watcher_user_ids, :json, default: [], null: false
```

That cannot be adopted: MySQL rejects a literal default on a json column (`ERROR 1101: BLOB, TEXT, GEOMETRY or JSON column 'k' can't have a default value`), so the migration would fail on MySQL installs, and `null: false` would need a backfill for rows that already hold NULL.

The bug it was working around is already fixed in the model: every json column declares `attribute ..., default: []` and its reader wraps the value in `Array(...)`, and `watcher_user_ids` has a persisted-NULL test. So this PR only closes the gap that made the fork's change look necessary:

- a test that a row whose `subtasks`, `relations`, `weekdays` and `month_weeks` were set to NULL outside the model still reads as `[]` and can generate an issue and a next run date;
- a comment on the `attribute` block recording why the defaults live in the model and not in the schema, so the DB-level default is not attempted again.


Link to Devin session: https://app.devin.ai/sessions/3fb539ab13694d6a82edab4fd1e9a863
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fb539ab13694d6a82edab4fd1e9a863?variant=devin
Requested by: @jperelli