### PR TITLE
Build the category selector from the project's categories

### DIFF
--- a/app/views/periodictask/_form.html.erb
+++ b/app/views/periodictask/_form.html.erb
@@ -72,7 +72,7 @@
       <p>
         <%= label(:periodictask, :issue_category_id) do %><%= l(:field_category) %> <span class="required">*</span><% end %>
         <% if @categories.length > 0 %>
-          <%= f.select :issue_category_id, principals_options_for_select(@categories, @periodictask.issue_category), :include_blank => true, :required => true %>
+          <%= f.select :issue_category_id, @categories.pluck(:name, :id), :include_blank => true, :required => true %>
         <% else %>
           <%= l(:no_categories_in_project) %>
         <% end %>

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -178,6 +178,19 @@ class PeriodictaskControllerTest < ActionController::TestCase
     assert_select '.progress.attribute', 0
   end
 
+  def test_edit_lists_project_categories_and_selects_the_configured_one
+    task = create_test_periodictask(issue_category_id: 2)
+
+    get :edit, params: { project_id: 'ecookbook', id: task.id }
+
+    assert_select '#periodictask_issue_category_id' do
+      assert_select 'option[value="1"]', text: 'Printing'
+      assert_select 'option[selected="selected"][value="2"]', text: 'Recipes'
+      assert_select 'option[value="3"]', 0
+      assert_select 'optgroup', 0
+    end
+  end
+
   def test_edit_with_nil_watcher_user_ids
     task = create_test_periodictask
     task.update_column(:watcher_user_ids, nil)


### PR DESCRIPTION
## Summary

The category field renders its options with `principals_options_for_select`, a helper meant for users and groups:

```diff
-f.select :issue_category_id, principals_options_for_select(@categories, @periodictask.issue_category), ...
+f.select :issue_category_id, @categories.pluck(:name, :id), ...
```

It happens to produce the right markup today, but it carries principal-specific behaviour that does not belong to categories and will misbehave as Redmine evolves: it injects a `<< me >>` option when the collection contains `User.current`, splits options into `Group`/`User` optgroups, and adds an "involved principals" optgroup whenever `@issue` is set (populated from `@issue.author`/`prior_assigned_to`), which is a page-level ivar the plugin does not own. It also relied on passing the selected `IssueCategory` object explicitly instead of letting Rails derive it from `issue_category_id`.

`@categories` is `@project.issue_categories`, already ordered by name, so the option order is unchanged — this matches how Redmine core builds the same field in `issues/_attributes`.

Covered by a functional test asserting the edit form lists this project's categories only, marks the configured one selected, and emits no optgroups.

## Screenshot

Category dropdown built from the project's issue categories:

![Category dropdown built from the project's issue categories](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctYzIwOWY1ZWJjNTQ2NGUxODhkMjg4M2VhYjA3YjQ2N2YiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctYzIwOWY1ZWJjNTQ2NGUxODhkMjg4M2VhYjA3YjQ2N2YvNzUxY2E1YmUtYmY3Zi00ZWM4LWI5OWYtNTFjNGM4M2U0MWRjIiwiaWF0IjoxNzg4NjI5OTA5LCJleHAiOjE3ODkyMzQ3MDksImZpbGVuYW1lIjoicHIxNTctY2F0ZWdvcnktc2VsZWN0LnBuZyJ9.1F2WI983dr8Bh5KYhD93ajpO930B6qt0ATTK4Z5Bvp4)


Link to Devin session: https://app.devin.ai/sessions/3fb539ab13694d6a82edab4fd1e9a863
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fb539ab13694d6a82edab4fd1e9a863?variant=devin
Requested by: @jperelli