### PR TITLE
Share one checklists plugin check between model and helper

### DIFF
--- a/app/helpers/periodictask_helper.rb
+++ b/app/helpers/periodictask_helper.rb
@@ -129,7 +129,7 @@ module PeriodictaskHelper
   end
 
   def checklist_plugin_installed?
-    Redmine::Plugin.all.any? { |p| p.id == :redmine_checklists } && Object.const_defined?('ChecklistTemplate')
+    Periodictask.checklists_plugin_installed?
   end
 
   def template_options_for_select(project = nil, selected_id = nil)

--- a/app/models/periodictask.rb
+++ b/app/models/periodictask.rb
@@ -127,6 +127,12 @@ class Periodictask < ActiveRecord::Base
     Issue.method_defined?(:tag_list=) && Issue.respond_to?(:available_tags)
   end
 
+  # True when the redmine_checklists plugin is registered and its template
+  # model is loaded, so checklists can be copied onto generated issues.
+  def self.checklists_plugin_installed?
+    Redmine::Plugin.all.any? { |p| p.id == :redmine_checklists } && Object.const_defined?('ChecklistTemplate')
+  end
+
   # Tracker the generated issues will use: the configured one or the project's first.
   def effective_tracker
     tracker || project&.trackers&.first
@@ -450,21 +456,13 @@ class Periodictask < ActiveRecord::Base
   end
 
   def fill_checklists(issue)
-    if checklists_template_id && Redmine::Plugin.all.any? do |p|
-      p.id == :redmine_checklists
-    end && Object.const_defined?('ChecklistTemplate')
-      template = ChecklistTemplate.find(checklists_template_id)
-      if template
-        items = template.template_items.split("\n")
-        checklists = items.each_with_index.map do |x, i|
-          {
-            is_done: false,
-            subject: x,
-            position: i
-          }
-        end
-        issue.checklists_attributes = checklists
-      end
+    return unless checklists_template_id && self.class.checklists_plugin_installed?
+
+    template = ChecklistTemplate.find_by(id: checklists_template_id)
+    return unless template
+
+    issue.checklists_attributes = template.template_items.split("\n").each_with_index.map do |subject, position|
+      { is_done: false, subject: subject, position: position }
     end
   end
 

--- a/test/unit/periodictasks_test.rb
+++ b/test/unit/periodictasks_test.rb
@@ -865,6 +865,36 @@ class PeriodictasksTest < ActiveSupport::TestCase
     end
   end
 
+  # --- Checklists ---
+
+  def test_generate_issue_ignores_checklists_without_checklists_plugin
+    skip 'the checklists plugin is installed' if Periodictask.checklists_plugin_installed?
+
+    task = Periodictask.new(project: @project, tracker_id: 1, author_id: 1, subject: 'Checklist',
+                            checklists_template_id: 1)
+    assert_not task.generate_issue.respond_to?(:checklists_attributes)
+  end
+
+  def test_generate_issue_fills_checklists_when_plugin_present
+    with_fake_checklists_plugin("First\nSecond") do
+      task = Periodictask.new(project: @project, tracker_id: 1, author_id: 1, subject: 'Checklist',
+                              checklists_template_id: 1)
+
+      assert_equal [{ is_done: false, subject: 'First', position: 0 },
+                    { is_done: false, subject: 'Second', position: 1 }],
+                   task.generate_issue.checklists_attributes
+    end
+  end
+
+  def test_generate_issue_ignores_a_deleted_checklist_template
+    with_fake_checklists_plugin("First\nSecond") do
+      task = Periodictask.new(project: @project, tracker_id: 1, author_id: 1, subject: 'Checklist',
+                              checklists_template_id: 404)
+
+      assert_nil task.generate_issue.checklists_attributes
+    end
+  end
+
   # --- Subtasks and relations ---
 
   def test_subtasks_accepts_indexed_hash_and_drops_blank_rows
@@ -980,6 +1010,21 @@ class PeriodictasksTest < ActiveSupport::TestCase
   end
 
   private
+
+  # Mimics the redmine_checklists plugin: a ChecklistTemplate model holding the
+  # items as one string per line, and checklists_attributes= on Issue.
+  def with_fake_checklists_plugin(template_items)
+    template = Struct.new(:template_items).new(template_items)
+    Object.const_set(:ChecklistTemplate, Class.new do
+      define_singleton_method(:find_by) { |id:| id == 1 ? template : nil }
+    end)
+    Issue.class_eval { attr_accessor :checklists_attributes }
+    Periodictask.stubs(:checklists_plugin_installed?).returns(true)
+    yield
+  ensure
+    Object.send(:remove_const, :ChecklistTemplate)
+    Issue.send(:remove_method, :checklists_attributes, :checklists_attributes=)
+  end
 
   # Mimics the API the RedmineUP Tags plugin adds to Issue (acts_as_taggable).
   def with_fake_tagging_plugin


### PR DESCRIPTION
## Summary

The redmine_checklists detection was duplicated: the helper's `checklist_plugin_installed?` and an inline copy inside `Periodictask#fill_checklists`. They are now one predicate next to the existing `tags_plugin_installed?`:

```ruby
def self.checklists_plugin_installed?
  Redmine::Plugin.all.any? { |p| p.id == :redmine_checklists } && Object.const_defined?('ChecklistTemplate')
end
```

`fill_checklists` also loses a bug along the way: it used `ChecklistTemplate.find`, which raises `RecordNotFound` when the referenced template has been deleted — so a stale `checklists_template_id` made issue generation fail for that task. It now uses `find_by` and skips the checklists (the `if template` guard was dead code under `find`).

```diff
-if checklists_template_id && Redmine::Plugin.all.any? { |p| p.id == :redmine_checklists } && Object.const_defined?('ChecklistTemplate')
-  template = ChecklistTemplate.find(checklists_template_id)
+return unless checklists_template_id && self.class.checklists_plugin_installed?
+template = ChecklistTemplate.find_by(id: checklists_template_id)
+return unless template
```

Tests fake the plugin (a `ChecklistTemplate` constant plus `Issue#checklists_attributes=`) and cover items being copied in order, a deleted template being ignored, and nothing happening when the plugin is absent.


Link to Devin session: https://app.devin.ai/sessions/3fb539ab13694d6a82edab4fd1e9a863
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fb539ab13694d6a82edab4fd1e9a863?variant=devin
Requested by: @jperelli