### PR TITLE
Add an active flag and a target version to periodic tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add Vietnamese (`vi`) translation, adapted from [@tq89](https://github.com/tq89)'s fork (@jperelli)
 - Add the shifted date macros `**NEXT_MONTH**`, `**NEXT_MONTHNAME**`, `**NEXT_WEEK**`, `**NEXT_WEEKISO**` and the year companions `**NEXT_MONTH_YEAR**`, `**NEXT_WEEK_YEAR**`, `**NEXT_WEEKISO_YEAR**`, `**PREVIOUS_MONTH_YEAR**`, `**WEEKISO_YEAR**` (idea and implementation from [tq89's fork](https://github.com/tq89/Redmine-Periodic-Task))
 
+
 ### Fixes
 
 - Apply the `Project` patch (`has_many :periodictasks, dependent: :destroy`) at plugin load; the nested `to_prepare` it used never ran outside code reloading (@jperelli)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - Add a `Copy` action that opens the new task form prefilled from an existing task, inspired by [@vegaminer](https://github.com/vegaminer)'s fork (@jperelli)
 - Add Vietnamese (`vi`) translation, adapted from [@tq89](https://github.com/tq89)'s fork (@jperelli)
 - Add the shifted date macros `**NEXT_MONTH**`, `**NEXT_MONTHNAME**`, `**NEXT_WEEK**`, `**NEXT_WEEKISO**` and the year companions `**NEXT_MONTH_YEAR**`, `**NEXT_WEEK_YEAR**`, `**NEXT_WEEKISO_YEAR**`, `**PREVIOUS_MONTH_YEAR**`, `**WEEKISO_YEAR**` (idea and implementation from [tq89's fork](https://github.com/tq89/Redmine-Periodic-Task))
-
+- Add an `Active` flag to disable a task without deleting it: disabled tasks are skipped by the scheduler but can still be run with `Run now` **requires migration**, inspired by [@Luckyvb](https://github.com/Luckyvb)'s and [@rkteam](https://github.com/rkteam)'s forks (@jperelli)
+- Add a configurable `Target version` for the generated issues **requires migration** (@jperelli)
 
 ### Fixes
 

--- a/app/controllers/periodictask_controller.rb
+++ b/app/controllers/periodictask_controller.rb
@@ -9,11 +9,13 @@ class PeriodictaskController < ApplicationController
   before_action :authorize
   before_action :load_users, except: %i[destroy run_now tags]
   before_action :load_categories, except: %i[destroy run_now tags]
+  before_action :load_versions, except: %i[destroy run_now tags]
 
   helper :custom_fields
   include CustomFieldsHelper
 
   helper :issues
+  helper :projects
   helper :watchers
   helper :queries
   helper :sort
@@ -210,6 +212,12 @@ class PeriodictaskController < ApplicationController
     @categories = @project.issue_categories
   end
 
+  # Versions that can be set on a new issue: the project's own and the ones
+  # shared with it, closed ones excluded like Redmine's issue form.
+  def load_versions
+    @versions = @project.shared_versions.open.to_a
+  end
+
   # The form posts next_run_date as a wall-clock time without an offset; parse
   # it in the same zone the list/show pages use to display it (format_time).
   def assign_periodictask_params
@@ -232,6 +240,7 @@ class PeriodictaskController < ApplicationController
       :interval_number, :interval_units, :next_run_date, :set_start_date,
       :due_date_number, :due_date_units, :description, :issue_category_id,
       :estimated_hours, :checklists_template_id, :parent_id, :priority_id, :status_id, :done_ratio, :tag_list,
+      :fixed_version_id, :is_active,
       :monthly_mode,
       { weekdays: [] },
       { month_weeks: [] },

--- a/app/helpers/periodictask_helper.rb
+++ b/app/helpers/periodictask_helper.rb
@@ -52,6 +52,19 @@ module PeriodictaskHelper
             class: 'icon-only icon-help', title: title, target: '_blank', rel: 'noopener'
   end
 
+  # Target version options: the project's open versions plus the task's own
+  # one, so editing a task whose version has since been closed keeps it.
+  def periodictask_version_options(versions, periodictask)
+    version_options_for_select((versions + [periodictask.fixed_version]).compact.uniq, periodictask.fixed_version)
+  end
+
+  # Marker shown next to a disabled task's subject in the list and detail pages.
+  def periodictask_disabled_icon(periodictask)
+    return if periodictask.is_active?
+
+    content_tag(:span, '', title: l(:label_disabled), class: 'icon-only icon-locked')
+  end
+
   def periodictask_default_label(value)
     ["(#{l(:label_default)})", value].compact.join(' - ')
   end

--- a/app/models/periodictask.rb
+++ b/app/models/periodictask.rb
@@ -7,6 +7,7 @@ class Periodictask < ActiveRecord::Base
   belongs_to :assigned_to, class_name: 'Principal', foreign_key: 'assigned_to_id'
   belongs_to :tracker, optional: true
   belongs_to :issue_category, class_name: 'IssueCategory', foreign_key: 'issue_category_id'
+  belongs_to :fixed_version, class_name: 'Version', foreign_key: 'fixed_version_id', optional: true
   has_many :periodictask_issues, dependent: :delete_all
   has_many :issues, through: :periodictask_issues
   attribute :custom_field_values, :json
@@ -164,6 +165,10 @@ class Periodictask < ActiveRecord::Base
   validate :validate_recurrence
   before_validation :clear_irrelevant_recurrence_options
 
+  # Tasks the scheduler picks up. A disabled task keeps its schedule and can
+  # still be run by hand from the list or detail page.
+  scope :active, -> { where(is_active: true) }
+
   scope :accessible, lambda {
     if User.current.allowed_to?(:periodictask, nil, global: true)
       all
@@ -227,6 +232,7 @@ class Periodictask < ActiveRecord::Base
                       category_id: issue_category_id, parent_id: parent_id,
                       assigned_to_id: assigned_to_id, author_id: author_id,
                       subject: subj, description: desc)
+    issue.fixed_version_id = fixed_version_id if fixed_version_id.present?
     issue.priority_id = priority_id if priority_id.present?
     issue.status_id = status_id if status_id.present?
     issue.done_ratio = done_ratio if done_ratio.present? && done_ratio_enabled?

--- a/app/views/periodictask/_form.html.erb
+++ b/app/views/periodictask/_form.html.erb
@@ -6,6 +6,10 @@
 <fieldset class="box tabular">
   <legend><%= l(:label_periodictask_configuration) %></legend>
   <p>
+    <%= label(:periodictask, :is_active, l(:field_active)) %>
+    <%= f.check_box :is_active %>
+  </p>
+  <p>
     <%= label(:periodictask, :interval_number) do %><%= l(:label_interval) %> <span class="required">*</span><% end %>
     <%= f.number_field :interval_number, :required => true, :min => 1 %>
     <%= select 'periodictask', 'interval_units', Periodictask.interval_units_options %>
@@ -80,6 +84,10 @@
     </div>
 
     <div class="splitcontentright">
+      <p>
+        <%= label(:periodictask, :fixed_version_id, l(:field_fixed_version)) %>
+        <%= f.select :fixed_version_id, periodictask_version_options(@versions, @periodictask), :include_blank => true %>
+      </p>
       <p>
         <%= label(:periodictask, :parent_id, l(:field_parent_issue)) %><%= f.text_field :parent_id, :size => 10 %>
       </p>

--- a/app/views/periodictask/index.html.erb
+++ b/app/views/periodictask/index.html.erb
@@ -37,6 +37,7 @@
           <td><%= a.tracker&.name %></td>
           <td><%= @priorities[a.priority_id]&.name %></td>
           <td>
+            <%= periodictask_disabled_icon(a) %>
             <%= content_tag('span', '', :title => a.last_error, :class => 'icon-only icon-error') if a.last_error.present? %>
             <%= link_to a.subject, {:controller => 'periodictask', :action => 'show', :id => a.id, :project_id => @project} %>
           </td>

--- a/app/views/periodictask/show.html.erb
+++ b/app/views/periodictask/show.html.erb
@@ -34,6 +34,9 @@
       rows.right l(:label_next_run_date),
                  periodictask_time_with_title(@periodictask.next_run_date),
                  class: 'next-run-date'
+      rows.left l(:field_active),
+                checked_image(@periodictask.is_active?),
+                class: 'active'
     end %>
   </div>
 </div>
@@ -89,6 +92,9 @@
       rows.left l(:field_category),
                 (@periodictask.issue_category&.name || '-'),
                 class: 'category'
+      rows.left l(:field_fixed_version),
+                (@periodictask.fixed_version ? link_to_version(@periodictask.fixed_version) : '-'),
+                class: 'fixed-version'
 
       rows.right l(:label_set_start_date),
                  checked_image(@periodictask.set_start_date?),

--- a/db/migrate/20260909000000_add_active_and_fixed_version_to_periodictasks.rb
+++ b/db/migrate/20260909000000_add_active_and_fixed_version_to_periodictasks.rb
@@ -1,0 +1,15 @@
+active_record_migration_class = ActiveRecord::Migration.respond_to?(:current_version) ? ActiveRecord::Migration[4.2] : ActiveRecord::Migration
+
+class AddActiveAndFixedVersionToPeriodictasks < active_record_migration_class
+  def self.up
+    add_column :periodictasks, :is_active, :boolean, :null => false, :default => true
+    add_column :periodictasks, :fixed_version_id, :integer, :null => true, :default => nil
+    add_index :periodictasks, [:is_active, :next_run_date]
+  end
+
+  def self.down
+    remove_index :periodictasks, [:is_active, :next_run_date]
+    remove_column :periodictasks, :is_active
+    remove_column :periodictasks, :fixed_version_id
+  end
+end

--- a/lib/scheduled_tasks_checker.rb
+++ b/lib/scheduled_tasks_checker.rb
@@ -6,7 +6,7 @@ class ScheduledTasksChecker
     now = Time.current
     errors = []
     issues_created = 0
-    tasks = Periodictask.where('next_run_date <= ? ', now).to_a
+    tasks = Periodictask.active.where('next_run_date <= ? ', now).to_a
 
     tasks.each do |task|
       # replace variables (set locale from shell)

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -3,7 +3,7 @@ require "#{File.dirname(__FILE__)}/../test_helper"
 class PeriodictaskControllerTest < ActionController::TestCase
   fixtures :projects, :users, :email_addresses, :roles, :members, :member_roles,
            :trackers, :projects_trackers, :enabled_modules, :issue_statuses,
-           :enumerations, :issue_categories, :issues
+           :enumerations, :issue_categories, :issues, :versions
 
   def setup
     @project = Project.find(1)
@@ -662,6 +662,41 @@ class PeriodictaskControllerTest < ActionController::TestCase
     task = create_test_periodictask
     get :index, params: { project_id: 'ecookbook' }
     assert_select 'a[href=?]', copy_periodictask_path(project_id: 'ecookbook', id: task.id)
+  end
+
+  def test_edit_offers_open_versions_and_keeps_the_configured_one
+    # Version 1 is closed, 2 is locked, 3 is open (all on ecookbook).
+    task = create_test_periodictask(fixed_version_id: 1)
+    get :edit, params: { project_id: 'ecookbook', id: task.id }
+    assert_response :success
+    assert_select 'select#periodictask_fixed_version_id' do
+      assert_select 'option[value=?]', '3'
+      assert_select 'option[value=?]', '2', 0
+      assert_select 'option[selected=selected][value=?]', '1'
+    end
+  end
+
+  def test_create_stores_target_version_and_disabled_state
+    post :create, params: {
+      project_id: 'ecookbook',
+      periodictask: {
+        subject: 'Versioned task', tracker_id: 1, assigned_to_id: 2, author_id: 2,
+        interval_number: 1, interval_units: 'month', fixed_version_id: '3', is_active: '0'
+      }
+    }
+    assert_response :redirect
+
+    task = Periodictask.find_by(subject: 'Versioned task')
+    assert_equal 3, task.fixed_version_id
+    assert_not task.is_active?
+  end
+
+  def test_run_now_works_on_a_disabled_task
+    task = create_test_periodictask(is_active: false)
+    assert_difference('Issue.count') do
+      post :run_now, params: { project_id: 'ecookbook', id: task.id }
+    end
+    assert_response :redirect
   end
 
   def test_denies_member_without_permission

--- a/test/functional/periodictask_settings_test.rb
+++ b/test/functional/periodictask_settings_test.rb
@@ -9,6 +9,9 @@ class PeriodictaskSettingsTest < Redmine::IntegrationTest
     # A checker running in its own thread writes outside the test transaction,
     # so its rows would survive into the next test.
     RedminePeriodictask::WebScheduler.synchronous = true
+    # Requests made in web mode would otherwise run the checker in a thread of
+    # their own, which writes its run outside the test transaction.
+    RedminePeriodictask::WebScheduler.synchronous = true
     log_user('admin', 'admin')
     PeriodictaskRun.delete_all
   end
@@ -16,6 +19,7 @@ class PeriodictaskSettingsTest < Redmine::IntegrationTest
   def teardown
     RedminePeriodictask::WebScheduler.synchronous = false
     RedminePeriodictask::WebScheduler.reset!
+    RedminePeriodictask::WebScheduler.synchronous = false
     Setting.plugin_periodictask = { 'scheduler_mode' => 'cron' }
   end
 

--- a/test/functional/periodictask_settings_test.rb
+++ b/test/functional/periodictask_settings_test.rb
@@ -9,9 +9,6 @@ class PeriodictaskSettingsTest < Redmine::IntegrationTest
     # A checker running in its own thread writes outside the test transaction,
     # so its rows would survive into the next test.
     RedminePeriodictask::WebScheduler.synchronous = true
-    # Requests made in web mode would otherwise run the checker in a thread of
-    # their own, which writes its run outside the test transaction.
-    RedminePeriodictask::WebScheduler.synchronous = true
     log_user('admin', 'admin')
     PeriodictaskRun.delete_all
   end
@@ -19,7 +16,6 @@ class PeriodictaskSettingsTest < Redmine::IntegrationTest
   def teardown
     RedminePeriodictask::WebScheduler.synchronous = false
     RedminePeriodictask::WebScheduler.reset!
-    RedminePeriodictask::WebScheduler.synchronous = false
     Setting.plugin_periodictask = { 'scheduler_mode' => 'cron' }
   end
 

--- a/test/unit/periodictasks_test.rb
+++ b/test/unit/periodictasks_test.rb
@@ -2,7 +2,8 @@ require "#{File.dirname(__FILE__)}/../test_helper"
 
 class PeriodictasksTest < ActiveSupport::TestCase
   fixtures :projects, :users, :trackers, :projects_trackers, :issue_statuses,
-           :enumerations, :enabled_modules, :roles, :members, :member_roles
+           :enumerations, :enabled_modules, :roles, :members, :member_roles,
+           :versions
 
   def setup
     @project = Project.find(1)
@@ -1070,6 +1071,43 @@ class PeriodictasksTest < ActiveSupport::TestCase
     assert_nil copy.last_error
     assert_equal 3, copy.author_id
     assert copy.save
+  end
+
+  def test_task_is_active_by_default
+    task = Periodictask.create!(
+      project: @project, tracker_id: 1, assigned_to_id: 2, author_id: 2,
+      subject: 'Active by default', interval_number: 1, interval_units: 'month'
+    )
+
+    assert task.reload.is_active?
+  end
+
+  def test_checker_ignores_disabled_tasks
+    Periodictask.create!(
+      project: @project, tracker_id: 1, assigned_to_id: 2, author_id: 2,
+      subject: 'Disabled task', interval_number: 1, interval_units: 'month',
+      next_run_date: 1.day.ago, is_active: false
+    )
+
+    assert_no_difference('Issue.count') do
+      ScheduledTasksChecker.checktasks!
+    end
+  end
+
+  def test_generated_issue_gets_the_target_version
+    version = Version.find(3)
+    task = Periodictask.create!(
+      project: @project, tracker_id: 1, assigned_to_id: 2, author_id: 2,
+      subject: 'Versioned task', interval_number: 1, interval_units: 'month',
+      next_run_date: 1.day.ago, fixed_version_id: version.id
+    )
+
+    assert_difference('Issue.count') do
+      ScheduledTasksChecker.checktasks!
+    end
+
+    assert_equal version, Issue.where(subject: 'Versioned task').last.fixed_version
+    assert_nil task.reload.last_error
   end
 
   private


### PR DESCRIPTION
## Summary

Two features that several forks added independently ([@Luckyvb](https://github.com/Luckyvb) as `is_disabled`, later renamed to `is_active` in [@rkteam](https://github.com/rkteam)'s fork), reimplemented on the current schema instead of cherry-picking their migrations:

- `is_active` (default `true`, indexed together with `next_run_date`) lets you park a task without deleting it. Only the scheduler honours it — `Run now` deliberately still works, so you can test a task before enabling it:
  ```ruby
  # lib/scheduled_tasks_checker.rb
  Periodictask.active.where('next_run_date <= ?', now)
  ```
- `fixed_version_id` sets the `Target version` of every generated issue.

The version selector mirrors Redmine's own `Issue#assignable_versions` rule rather than just listing `shared_versions.open`: the task's configured version is appended to the options so editing a task whose version was closed or locked meanwhile doesn't silently drop it.

```ruby
version_options_for_select((versions + [periodictask.fixed_version]).compact.uniq, periodictask.fixed_version)
```

All labels reuse Redmine core keys (`field_active`, `field_fixed_version`, `label_disabled`), so no locale files change.

## Screenshot

The new `Active` checkbox and the `Target version` selector on the task form:

![The new `Active` checkbox and the `Target version` selector on the task form](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctYzIwOWY1ZWJjNTQ2NGUxODhkMjg4M2VhYjA3YjQ2N2YiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctYzIwOWY1ZWJjNTQ2NGUxODhkMjg4M2VhYjA3YjQ2N2YvZTBhYTJlYzItNGE0NS00MWRkLTg5ZjMtMmZhMjg3NWJjOTVmIiwiaWF0IjoxNzg4NjI5OTA5LCJleHAiOjE3ODkyMzQ3MDksImZpbGVuYW1lIjoicHIxNjEtYWN0aXZlLWFuZC10YXJnZXQtdmVyc2lvbi5wbmcifQ.6DN8i22Ya9eRVpr8QsvTKDNKXVZwVJj6yq0phduYKVQ)


Link to Devin session: https://app.devin.ai/sessions/3fb539ab13694d6a82edab4fd1e9a863
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fb539ab13694d6a82edab4fd1e9a863?variant=devin
Requested by: @jperelli