### PR TITLE
Add a copy action that prefills the new task form from an existing task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add `GET|POST /periodictask/check?key=<sys API key>` to trigger the checker from an external scheduler (uptime monitor, CI cron, Windows Task Scheduler...) (@jperelli)
 - Scheduler log on the plugin configuration page: the last 50 checker runs (trigger, tasks due, issues created, duration, errors), with consecutive idle runs grouped in one row, plus a *Run checker now* button **requires migration** (@jperelli)
 - Add an `Administration` > `Periodic Tasks` page listing the tasks of every project, inspired by [@rkteam](https://github.com/rkteam)'s fork (@jperelli)
-
+- Add a `Copy` action that opens the new task form prefilled from an existing task, inspired by [@vegaminer](https://github.com/vegaminer)'s fork (@jperelli)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Scheduler log on the plugin configuration page: the last 50 checker runs (trigger, tasks due, issues created, duration, errors), with consecutive idle runs grouped in one row, plus a *Run checker now* button **requires migration** (@jperelli)
 - Add an `Administration` > `Periodic Tasks` page listing the tasks of every project, inspired by [@rkteam](https://github.com/rkteam)'s fork (@jperelli)
 
+
 ### Fixes
 
 - Apply the `Project` patch (`has_many :periodictasks, dependent: :destroy`) at plugin load; the nested `to_prepare` it used never ran outside code reloading (@jperelli)

--- a/app/controllers/periodictask_controller.rb
+++ b/app/controllers/periodictask_controller.rb
@@ -87,6 +87,15 @@ class PeriodictaskController < ApplicationController
     end
   end
 
+  # Prefills the new task form from an existing task; nothing is stored until
+  # the form is submitted.
+  def copy
+    source = Periodictask.accessible.find(params[:id])
+    @periodictask = Periodictask.new(project: @project, author_id: User.current.id).copy_from(source)
+    @issue = @periodictask.generate_issue
+    render action: 'new'
+  end
+
   def edit
     @periodictask = Periodictask.accessible.find(params[:id])
     @periodictask.project = @project

--- a/app/models/periodictask.rb
+++ b/app/models/periodictask.rb
@@ -19,6 +19,10 @@ class Periodictask < ActiveRecord::Base
   SUBTASK_KEYS = %w[tracker_id subject assigned_to_id estimated_hours].freeze
   RELATION_KEYS = %w[relation_type issue_id delay].freeze
 
+  # Identity, ownership and the outcome of past runs belong to the source task;
+  # everything else describes the template and is worth copying.
+  COPY_EXCLUDED_ATTRIBUTES = %w[id project_id author_id created_at updated_at last_error].freeze
+
   # Subtask templates: array of hashes with SUBTASK_KEYS, each becoming a child
   # issue of the generated issue. Accepts an array or an index-keyed hash as
   # posted by the form; blank rows are dropped.
@@ -196,6 +200,13 @@ class Periodictask < ActiveRecord::Base
       [l(:label_unit_month), 'month'],
       [l(:label_unit_year), 'year']
     ]
+  end
+
+  # Takes over the schedule and issue template of another task, leaving the
+  # project and author of this one untouched.
+  def copy_from(source)
+    self.attributes = source.attributes.except(*COPY_EXCLUDED_ATTRIBUTES)
+    self
   end
 
   def generate_issue(now = Time.current)

--- a/app/views/periodictask/index.html.erb
+++ b/app/views/periodictask/index.html.erb
@@ -49,6 +49,11 @@
               :class => 'icon-only icon-edit', :title => l(:button_edit)
             ) %>
             <%= link_to(
+              periodictask_sprite_icon('copy', l(:button_copy), icon_only: true),
+              {:controller => 'periodictask', :action => 'copy', :id => a.id, :project_id => @project},
+              :class => 'icon-only icon-copy', :title => l(:button_copy)
+            ) %>
+            <%= link_to(
               periodictask_sprite_icon('reload', l(:button_run_now), icon_only: true),
               {:controller => 'periodictask', :action => 'run_now', :id => a.id, :project_id => @project},
               :method => :post,

--- a/app/views/periodictask/show.html.erb
+++ b/app/views/periodictask/show.html.erb
@@ -5,6 +5,11 @@
     class: 'icon icon-edit'
   ) %>
   <%= link_to(
+    periodictask_sprite_icon('copy', l(:button_copy)),
+    { controller: 'periodictask', action: 'copy', id: @periodictask.id, project_id: @project },
+    class: 'icon icon-copy'
+  ) %>
+  <%= link_to(
     periodictask_sprite_icon('reload', l(:button_run_now)),
     { controller: 'periodictask', action: 'run_now', id: @periodictask.id, project_id: @project },
     method: :post,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   post     'projects/:project_id/periodictask',            to: 'periodictask#create'
   get      'projects/:project_id/periodictask/:id',        to: 'periodictask#show',   as: 'periodictask'
   get      'projects/:project_id/periodictask/:id/edit',   to: 'periodictask#edit',   as: 'edit_periodictask'
+  get      'projects/:project_id/periodictask/:id/copy',   to: 'periodictask#copy',   as: 'copy_periodictask'
   post     'projects/:project_id/periodictask/:id/run_now', to: 'periodictask#run_now', as: 'run_now_periodictask'
   match    'projects/:project_id/periodictask/:id',        to: 'periodictask#update', via: %i[put patch]
   delete   'projects/:project_id/periodictask/:id',        to: 'periodictask#destroy'

--- a/init.rb
+++ b/init.rb
@@ -36,7 +36,7 @@ Redmine::Plugin.register :periodictask do
 
   project_module :periodictask do
     permission :periodictask,
-               { periodictask: %i[index show new create edit update destroy customfields run_now tags] }
+               { periodictask: %i[index show new create copy edit update destroy customfields run_now tags] }
   end
 
   # Surface create/update/delete of periodic tasks in the activity log, gated by

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -630,6 +630,27 @@ class PeriodictaskControllerTest < ActionController::TestCase
     assert_select '.interval .value', text: expected
   end
 
+  def test_copy_prefills_the_new_form_without_saving
+    task = create_test_periodictask(subject: 'Weekly backup', interval_number: 3,
+                                    interval_units: 'week', description: 'Run the backup')
+
+    assert_no_difference('Periodictask.count') do
+      get :copy, params: { project_id: 'ecookbook', id: task.id }
+    end
+    assert_response :success
+    assert_select 'input#periodictask_subject[value=?]', 'Weekly backup'
+    assert_select 'input#periodictask_interval_number[value=?]', '3'
+    assert_select 'select#periodictask_interval_units option[value=week][selected=selected]'
+    assert_select 'textarea#periodictask_description', text: 'Run the backup'
+    assert_select 'input#periodictask_id[value]', 0 # a copy is a new record
+  end
+
+  def test_index_links_to_the_copy_action
+    task = create_test_periodictask
+    get :index, params: { project_id: 'ecookbook' }
+    assert_select 'a[href=?]', copy_periodictask_path(project_id: 'ecookbook', id: task.id)
+  end
+
   def test_denies_member_without_permission
     # dlopez (user 3) is a Developer member of ecookbook but the Developer role
     # was not granted the :periodictask permission in setup.

--- a/test/unit/periodictasks_test.rb
+++ b/test/unit/periodictasks_test.rb
@@ -960,6 +960,25 @@ class PeriodictasksTest < ActiveSupport::TestCase
     assert task.next_run_date > Time.current
   end
 
+  def test_copy_from_takes_the_template_but_not_the_identity
+    source = Periodictask.create!(
+      project: @project, tracker_id: 1, assigned_to_id: 2, author_id: 2,
+      subject: 'Source task', interval_number: 2, interval_units: 'week',
+      weekdays: [1, 3], subtasks: [{ 'subject' => 'Child' }], last_error: 'boom'
+    )
+
+    copy = Periodictask.new(project: @project, author_id: 3).copy_from(source)
+
+    assert_equal 'Source task', copy.subject
+    assert_equal [2, 'week'], [copy.interval_number, copy.interval_units]
+    assert_equal [1, 3], copy.weekdays
+    assert_equal [{ 'subject' => 'Child' }], copy.subtasks
+    assert_nil copy.id
+    assert_nil copy.last_error
+    assert_equal 3, copy.author_id
+    assert copy.save
+  end
+
   private
 
   # Mimics the API the RedmineUP Tags plugin adds to Issue (acts_as_taggable).


### PR DESCRIPTION
## Summary

[@vegaminer](https://github.com/vegaminer)'s fork added `Periodictask#copy` / `.copy_from` that saved the duplicate immediately (and pulled in their private `redmine_dit_kpi` plugin plus `puts` debugging). This is a clean reimplementation with the UI the fork lacked, and without persisting anything until the user submits the form:

```ruby
# PeriodictaskController
def copy
  source = Periodictask.accessible.find(params[:id])
  @periodictask = Periodictask.new(project: @project, author_id: User.current.id).copy_from(source)
  @issue = @periodictask.generate_issue
  render action: 'new'
end
```

`copy_from` assigns every attribute except the ones that belong to the source record rather than to its template:

```ruby
COPY_EXCLUDED_ATTRIBUTES = %w[id project_id author_id created_at updated_at last_error]
```

Copying via attribute assignment means the JSON columns (`weekdays`, `month_weeks`, `subtasks`, `relations`, `watcher_user_ids`, `custom_field_values`) and the tag list come along for free, and any future column is copied without touching this code.

A `Copy` button is added to the task list rows and the detail page, and `copy` is added to the `:periodictask` permission's action list so it is gated like the rest.

## Screenshot

The new task form prefilled after clicking `Copy` on an existing task:

![The new task form prefilled after clicking `Copy` on an existing task](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctYzIwOWY1ZWJjNTQ2NGUxODhkMjg4M2VhYjA3YjQ2N2YiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctYzIwOWY1ZWJjNTQ2NGUxODhkMjg4M2VhYjA3YjQ2N2YvYTViYzYwYjQtZjNkOC00YTI4LTk0MzQtY2ViN2IwOTFjMzkxIiwiaWF0IjoxNzg4NjI5OTA5LCJleHAiOjE3ODkyMzQ3MDksImZpbGVuYW1lIjoicHIxNjMtZHVwbGljYXRlLXRhc2sucG5nIn0.WtbzkaKsrZnHSC6lNTXoFfvBC0kTDWaBZrlDQVq1sNg)


Link to Devin session: https://app.devin.ai/sessions/3fb539ab13694d6a82edab4fd1e9a863
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fb539ab13694d6a82edab4fd1e9a863?variant=devin
Requested by: @jperelli