### PR TITLE
Keep the settings test from leaking a checker thread into later tests

### DIFF
--- a/test/functional/periodictask_settings_test.rb
+++ b/test/functional/periodictask_settings_test.rb
@@ -6,11 +6,16 @@ class PeriodictaskSettingsTest < Redmine::IntegrationTest
   def setup
     Setting.plugin_periodictask = { 'scheduler_mode' => 'cron' }
     RedminePeriodictask::WebScheduler.reset!
+    # A checker running in its own thread writes outside the test transaction,
+    # so its rows would survive into the next test.
+    RedminePeriodictask::WebScheduler.synchronous = true
     log_user('admin', 'admin')
     PeriodictaskRun.delete_all
   end
 
   def teardown
+    RedminePeriodictask::WebScheduler.synchronous = false
+    RedminePeriodictask::WebScheduler.reset!
     Setting.plugin_periodictask = { 'scheduler_mode' => 'cron' }
   end
 


### PR DESCRIPTION
## Summary

`PeriodictaskSettingsTest#test_plugin_settings_can_switch_to_web_mode` switches the plugin to `web` mode, so the redirect it follows goes through `WebScheduler.maybe_run!`, which spawns a checker `Thread`. That thread uses its own connection, i.e. it commits *outside* the test transaction and its rows survive into whatever test runs next — the likely source of two intermittent CI failures seen on unrelated branches:

- `PeriodictaskSettingsTest#test_plugin_settings_page_renders`: `p.nodata` missing, because a `PeriodictaskRun` appeared after `PeriodictaskRun.delete_all`.
- `WebSchedulerRequestTest#test_request_does_not_trigger_checker_in_cron_mode`: `PeriodictaskIssue.count` was 1 instead of 0.

Fix is test-only: run the checker inline for this test case (`WebScheduler.synchronous = true`, the accessor `WebSchedulerRequestTest` already uses) so it stays inside the transaction, and reset the scheduler in `teardown`.

```ruby
 def setup
   ...
+  RedminePeriodictask::WebScheduler.synchronous = true
 end

 def teardown
+  RedminePeriodictask::WebScheduler.synchronous = false
+  RedminePeriodictask::WebScheduler.reset!
   Setting.plugin_periodictask = { 'scheduler_mode' => 'cron' }
 end
```

Production behaviour is untouched. Both failures are timing-dependent and I could not reproduce them on demand, so this is a hardening fix rather than a demonstrated repro: verified on 7.0-bookworm with the two seeds that failed in CI (6540, 53842) plus a third, suite and RuboCop clean.


Link to Devin session: https://app.devin.ai/sessions/3fb539ab13694d6a82edab4fd1e9a863
Open in Devin Desktop: https://app.devin.ai/desktop/session/3fb539ab13694d6a82edab4fd1e9a863?variant=devin
Requested by: @jperelli