### PR TITLE
Post-merge consistency: scope task lookups to the URL project, restore request locale after checker runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Task pages only find tasks of the project in the URL: a user with the permission in one project could open, edit, copy, run or delete the tasks of any other project by id (@jperelli)
 - The checker restores the request locale after running, so the *Run checker now* flash message is shown in the admin's language instead of Redmine's default (@jperelli)
 - Show the disabled marker in the `Administration` > `Periodic Tasks` list like in the project list, and sort `business day` intervals by duration in the project list (@jperelli)
+- The disabled and last-error markers in the task lists were invisible on Redmine 6+/7 (empty legacy icon spans render nothing with SVG icons); they now use the sprite icons (@jperelli)
 
 ## v7.0.0 - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Apply the `Project` patch (`has_many :periodictasks, dependent: :destroy`) at plugin load; the nested `to_prepare` it used never ran outside code reloading (@jperelli)
 - `business day` intervals keep the scheduled time of day and no longer skip a day: the next run used to be moved to the start of the business day (09:00) whenever the task was scheduled outside business hours ([#79](https://github.com/jperelli/Redmine-Periodic-Task/issues/79), idea from [chris85618's fork](https://github.com/chris85618/Redmine-Periodic-Task))
 - A shifted month or an ISO week can now render a consistent year: `**PREVIOUS_MONTH**`/`**YEAR**` rendered `12/2026` when run in January 2026, and `**WEEKISO**`/`**YEAR**` was off by one around New Year
+- Task pages only find tasks of the project in the URL: a user with the permission in one project could open, edit, copy, run or delete the tasks of any other project by id (@jperelli)
+- The checker restores the request locale after running, so the *Run checker now* flash message is shown in the admin's language instead of Redmine's default (@jperelli)
+- Show the disabled marker in the `Administration` > `Periodic Tasks` list like in the project list, and sort `business day` intervals by duration in the project list (@jperelli)
 
 ## v7.0.0 - 2026-09-03
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ The plugin configuration page (*Administration → Plugins → Redmine periodict
 
 The *Run checker now* button on the same page runs the checker immediately, which is handy to test a setup without waiting for the scheduler.
 
+*Administration → Periodic Tasks* lists the tasks of every project in one table (disabled tasks and tasks whose last run failed are marked), with links to each task's detail and edit pages.
+
 ![Scheduler log on the plugin settings page, with a highlighted failed run](doc/screenshots/scheduler_log.png)
 
 ### Recurrence
@@ -219,13 +221,15 @@ calendar year around New Year (2025-12-29 is already ISO week 01 of 2026).
 
 The offset shifts the whole date, so combining the variables keeps them consistent across month and year boundaries — on 2027-01-01, `**DAY-1**/**MONTH-1**/**YEAR-1**` renders `31/12/2026`.
 
-If you want to get localized month names, please add `LOCALE="de"` (available are `bg`, `de`, `en`, `es`, `hr`, `it`, `ja`, `pl`, `pt-BR`, `ru`, `tr`, `uk`, `vi`, `zh`) to the cronjob like this
+If you want to get localized month names, please add `LOCALE="de"` (available are `bg`, `de`, `en`, `es`, `hr`, `it`, `ja`, `pl`, `pt-BR`, `ru`, `tr`, `uk`, `vi`, `zh`, `zh-TW`) to the cronjob like this
 
     0 * * * * cd /opt/redmine && /usr/local/bin/bundle exec rake redmine:check_periodictasks RAILS_ENV=production LOCALE="de"
 
 ## Plugins supported
 
 redmine-periodictask supports [redminecrm checklist PRO](https://www.redmineup.com/pages/plugins/checklists) to be used when creating a periodic task.
+
+When a tagging plugin ([RedmineUP Tags](https://www.redmineup.com/pages/plugins/tags) or [redmine_tags](https://github.com/ixti/redmine_tags)) is installed, the task form also gets a *Tags* field and the generated issues are tagged with it.
 
 ## Development
 

--- a/app/controllers/periodictask_controller.rb
+++ b/app/controllers/periodictask_controller.rb
@@ -7,6 +7,7 @@ class PeriodictaskController < ApplicationController
 
   before_action :find_project
   before_action :authorize
+  before_action :find_periodictask, only: %i[show edit update copy destroy run_now]
   before_action :load_users, except: %i[destroy run_now tags]
   before_action :load_categories, except: %i[destroy run_now tags]
   before_action :load_versions, except: %i[destroy run_now tags]
@@ -36,6 +37,7 @@ class PeriodictaskController < ApplicationController
     # duration (1 week > 1 day) instead of just the raw number.
     interval_days_sql = "#{Periodictask.table_name}.interval_number * " \
                         "CASE #{Periodictask.table_name}.interval_units " \
+                        "WHEN 'business_day' THEN 1.4 " \
                         "WHEN 'week' THEN 7 " \
                         "WHEN 'month' THEN 30 " \
                         "WHEN 'year' THEN 365 " \
@@ -92,21 +94,17 @@ class PeriodictaskController < ApplicationController
   # Prefills the new task form from an existing task; nothing is stored until
   # the form is submitted.
   def copy
-    source = Periodictask.accessible.find(params[:id])
-    @periodictask = Periodictask.new(project: @project, author_id: User.current.id).copy_from(source)
+    @periodictask = Periodictask.new(project: @project, author_id: User.current.id).copy_from(@periodictask)
     @issue = @periodictask.generate_issue
     render action: 'new'
   end
 
   def edit
-    @periodictask = Periodictask.accessible.find(params[:id])
-    @periodictask.project = @project
     params[:project_id] = @project[:identifier]
     @issue = @periodictask.generate_issue
   end
 
   def update
-    @periodictask = Periodictask.accessible.find(params[:id])
     params[:periodictask][:project_id] = @project[:id]
     assign_periodictask_params
     @issue = @periodictask.generate_issue
@@ -120,9 +118,6 @@ class PeriodictaskController < ApplicationController
   end
 
   def show
-    @periodictask = Periodictask.accessible.find(params[:id])
-    @periodictask.project = @project
-
     issue_ids = @periodictask.issues.pluck(:id)
     return if issue_ids.empty?
 
@@ -139,17 +134,14 @@ class PeriodictaskController < ApplicationController
   end
 
   def destroy
-    @task = Periodictask.accessible.find(params[:id])
-    @task.destroy
-    @task.log_activity('delete')
+    @periodictask.destroy
+    @periodictask.log_activity('delete')
     redirect_to controller: 'periodictask', action: 'index', project_id: params[:project_id]
   end
 
   # Generate an issue right now from the task config, without touching the
   # schedule. Handy for testing a task before its next run date arrives.
   def run_now
-    @periodictask = Periodictask.accessible.find(params[:id])
-    @periodictask.project = @project
     issue = @periodictask.generate_issue(Time.current)
 
     if issue.nil?
@@ -185,7 +177,7 @@ class PeriodictaskController < ApplicationController
 
   def customfields
     @periodictask = if params[:periodictask][:id].present?
-                      Periodictask.accessible.find(params[:periodictask][:id])
+                      project_periodictasks.find(params[:periodictask][:id])
                     else
                       Periodictask.new(project: @project, author_id: User.current.id)
                     end
@@ -197,6 +189,18 @@ class PeriodictaskController < ApplicationController
 
   def find_project
     @project = Project.find(params[:project_id])
+  end
+
+  # Tasks are always addressed through their own project, so a task id from
+  # another project is a 404 even for a user with the permission there.
+  def find_periodictask
+    @periodictask = project_periodictasks.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render_404
+  end
+
+  def project_periodictasks
+    @project.periodictasks.accessible
   end
 
   def load_users

--- a/app/helpers/periodictask_helper.rb
+++ b/app/helpers/periodictask_helper.rb
@@ -62,7 +62,22 @@ module PeriodictaskHelper
   def periodictask_disabled_icon(periodictask)
     return if periodictask.is_active?
 
-    content_tag(:span, '', title: l(:label_disabled), class: 'icon-only icon-locked')
+    periodictask_marker_icon('lock', 'icon-locked', l(:label_disabled))
+  end
+
+  # Marker shown next to a task's subject in the lists when its last run failed;
+  # the error message is the tooltip.
+  def periodictask_error_icon(periodictask)
+    return if periodictask.last_error.blank?
+
+    periodictask_marker_icon('warning', 'icon-error', periodictask.last_error)
+  end
+
+  # Icon-only marker with a tooltip. Redmine 6+ needs the SVG sprite inside the
+  # span (an empty `icon-*` span renders nothing since 7.0); Redmine 5 draws the
+  # icon from the CSS class.
+  def periodictask_marker_icon(sprite, css_class, title)
+    content_tag(:span, periodictask_sprite_icon(sprite), title: title, class: "icon-only #{css_class}")
   end
 
   def periodictask_default_label(value)

--- a/app/helpers/periodictask_helper.rb
+++ b/app/helpers/periodictask_helper.rb
@@ -58,7 +58,7 @@ module PeriodictaskHelper
     version_options_for_select((versions + [periodictask.fixed_version]).compact.uniq, periodictask.fixed_version)
   end
 
-  # Marker shown next to a disabled task's subject in the list and detail pages.
+  # Marker shown next to a disabled task's subject in the project and admin lists.
   def periodictask_disabled_icon(periodictask)
     return if periodictask.is_active?
 

--- a/app/views/periodictask/index.html.erb
+++ b/app/views/periodictask/index.html.erb
@@ -38,7 +38,7 @@
           <td><%= @priorities[a.priority_id]&.name %></td>
           <td>
             <%= periodictask_disabled_icon(a) %>
-            <%= content_tag('span', '', :title => a.last_error, :class => 'icon-only icon-error') if a.last_error.present? %>
+            <%= periodictask_error_icon(a) %>
             <%= link_to a.subject, {:controller => 'periodictask', :action => 'show', :id => a.id, :project_id => @project} %>
           </td>
           <td><%= a.assigned_to ? link_to_principal(a.assigned_to) : '-' %></td>

--- a/app/views/periodictask/index.html.erb
+++ b/app/views/periodictask/index.html.erb
@@ -59,7 +59,7 @@
               {:controller => 'periodictask', :action => 'run_now', :id => a.id, :project_id => @project},
               :method => :post,
               :data => { :confirm => l(:text_run_now_confirm) },
-              :class => 'icon-only', :title => l(:button_run_now)
+              :class => 'icon-only icon-reload', :title => l(:button_run_now)
             ) %>
             <%= delete_link(
               {:controller => 'periodictask', :action => 'destroy', :id => a.id, :project_id => @project},

--- a/app/views/periodictask_admin/index.html.erb
+++ b/app/views/periodictask_admin/index.html.erb
@@ -22,7 +22,7 @@
         <td><%= link_to task.project.name, project_path(task.project) %></td>
         <td class="subject">
           <%= periodictask_disabled_icon(task) %>
-          <%= content_tag('span', '', :title => task.last_error, :class => 'icon-only icon-error') if task.last_error.present? %>
+          <%= periodictask_error_icon(task) %>
           <%= link_to task.subject, periodictask_path(:project_id => task.project, :id => task.id) %>
         </td>
         <td class="interval"><%= periodictask_schedule_description(task) %></td>

--- a/app/views/periodictask_admin/index.html.erb
+++ b/app/views/periodictask_admin/index.html.erb
@@ -21,6 +21,7 @@
       <tr class="<%= cycle('odd', 'even') %>">
         <td><%= link_to task.project.name, project_path(task.project) %></td>
         <td class="subject">
+          <%= periodictask_disabled_icon(task) %>
           <%= content_tag('span', '', :title => task.last_error, :class => 'icon-only icon-error') if task.last_error.present? %>
           <%= link_to task.subject, periodictask_path(:project_id => task.project, :id => task.id) %>
         </td>

--- a/lib/scheduled_tasks_checker.rb
+++ b/lib/scheduled_tasks_checker.rb
@@ -8,33 +8,35 @@ class ScheduledTasksChecker
     issues_created = 0
     tasks = Periodictask.active.where('next_run_date <= ? ', now).to_a
 
-    tasks.each do |task|
-      # replace variables (set locale from shell)
-      I18n.locale = ENV['LOCALE'] || I18n.default_locale
-
-      as_user(task.author) do
-        issue = task.generate_issue(now)
-        if issue
-          begin
-            issue.save!
-            issues_created += 1
-            task_errors = task.complete_generated_issue(issue, now)
-            task_errors.each { |msg| Rails.logger.error "ScheduledTasksChecker: #{msg}" }
-            errors.concat(task_errors.map { |msg| "##{task.id} #{task.subject}: #{msg}" })
-            task.last_error = task_errors.join(', ').presence
-          rescue ActiveRecord::RecordInvalid => e
-            Rails.logger.error "ScheduledTasksChecker: #{e.message}"
-            errors << "##{task.id} #{task.subject}: #{e.message}"
-            task.last_error = e.message
+    # Macros render in the shell-configured locale (or Redmine's default). The
+    # checker also runs inside web requests, so the caller's locale must be
+    # restored afterwards.
+    I18n.with_locale(ENV['LOCALE'] || I18n.default_locale) do
+      tasks.each do |task|
+        as_user(task.author) do
+          issue = task.generate_issue(now)
+          if issue
+            begin
+              issue.save!
+              issues_created += 1
+              task_errors = task.complete_generated_issue(issue, now)
+              task_errors.each { |msg| Rails.logger.error "ScheduledTasksChecker: #{msg}" }
+              errors.concat(task_errors.map { |msg| "##{task.id} #{task.subject}: #{msg}" })
+              task.last_error = task_errors.join(', ').presence
+            rescue ActiveRecord::RecordInvalid => e
+              Rails.logger.error "ScheduledTasksChecker: #{e.message}"
+              errors << "##{task.id} #{task.subject}: #{e.message}"
+              task.last_error = e.message
+            end
+            task.next_run_date = task.get_next_run_date(now)
+          else
+            msg = 'Project is missing or closed'
+            Rails.logger.error "ScheduledTasksChecker: #{msg}"
+            errors << "##{task.id} #{task.subject}: #{msg}"
+            task.last_error = msg
           end
-          task.next_run_date = task.get_next_run_date(now)
-        else
-          msg = 'Project is missing or closed'
-          Rails.logger.error "ScheduledTasksChecker: #{msg}"
-          errors << "##{task.id} #{task.subject}: #{msg}"
-          task.last_error = msg
+          task.save
         end
-        task.save
       end
     end
     tasks.size

--- a/test/functional/periodictask_admin_controller_test.rb
+++ b/test/functional/periodictask_admin_controller_test.rb
@@ -24,6 +24,20 @@ class PeriodictaskAdminControllerTest < Redmine::IntegrationTest
     assert_select 'table.list td.subject a', text: 'Task on onlinestore'
   end
 
+  def test_index_marks_disabled_tasks
+    create_test_periodictask(Project.find(1), subject: 'Paused task', is_active: false)
+
+    log_user('admin', 'admin')
+    get '/admin/periodictasks'
+    assert_response :success
+    assert_select 'table.list td.subject', text: /Paused task/ do
+      assert_select 'span.icon-locked'
+    end
+    assert_select 'table.list td.subject', text: /Due task/ do
+      assert_select 'span.icon-locked', 0
+    end
+  end
+
   def test_index_is_sortable_by_each_column
     log_user('admin', 'admin')
     %w[project subject next_run_date].each do |column|
@@ -60,6 +74,16 @@ class PeriodictaskAdminControllerTest < Redmine::IntegrationTest
     assert_select 'div.flash.notice', text: /1 task/
     assert_select 'table.periodictask-runs tbody tr', 1
     assert_select 'table.periodictask-runs td', text: 'Manual'
+  end
+
+  def test_run_checker_flash_uses_the_admin_locale
+    User.find_by_login('admin').update!(language: 'es')
+
+    log_user('admin', 'admin')
+    post '/admin/periodictask/run_checker'
+    assert_redirected_to '/settings/plugin/periodictask'
+    follow_redirect!
+    assert_select 'div.flash.notice', text: I18n.t(:notice_periodictask_checker_run, count: 1, locale: :es)
   end
 
   def test_non_admin_is_forbidden

--- a/test/functional/periodictask_admin_controller_test.rb
+++ b/test/functional/periodictask_admin_controller_test.rb
@@ -31,10 +31,27 @@ class PeriodictaskAdminControllerTest < Redmine::IntegrationTest
     get '/admin/periodictasks'
     assert_response :success
     assert_select 'table.list td.subject', text: /Paused task/ do
-      assert_select 'span.icon-locked'
+      assert_select 'span.icon-locked[title=?]', I18n.t(:label_disabled)
+      # Redmine 6+ draws icons from the SVG sprite; an empty span shows nothing.
+      assert_select 'span.icon-locked svg' if Redmine::VERSION::MAJOR >= 6
     end
     assert_select 'table.list td.subject', text: /Due task/ do
       assert_select 'span.icon-locked', 0
+    end
+  end
+
+  def test_index_marks_tasks_whose_last_run_failed
+    create_test_periodictask(Project.find(1), subject: 'Broken task', last_error: 'Tracker cannot be blank')
+
+    log_user('admin', 'admin')
+    get '/admin/periodictasks'
+    assert_response :success
+    assert_select 'table.list td.subject', text: /Broken task/ do
+      assert_select 'span.icon-error[title=?]', 'Tracker cannot be blank'
+      assert_select 'span.icon-error svg' if Redmine::VERSION::MAJOR >= 6
+    end
+    assert_select 'table.list td.subject', text: /Due task/ do
+      assert_select 'span.icon-error', 0
     end
   end
 

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -699,6 +699,40 @@ class PeriodictaskControllerTest < ActionController::TestCase
     assert_response :redirect
   end
 
+  def test_task_of_another_project_is_not_reachable_through_this_project
+    other = create_test_periodictask(project: Project.find(2), subject: 'Onlinestore task')
+
+    get :show, params: { project_id: 'ecookbook', id: other.id }
+    assert_response 404
+    get :edit, params: { project_id: 'ecookbook', id: other.id }
+    assert_response 404
+    get :copy, params: { project_id: 'ecookbook', id: other.id }
+    assert_response 404
+    patch :update, params: { project_id: 'ecookbook', id: other.id, periodictask: { subject: 'Hijacked' } }
+    assert_response 404
+    assert_no_difference('Issue.count') do
+      post :run_now, params: { project_id: 'ecookbook', id: other.id }
+    end
+    assert_response 404
+    assert_no_difference('Periodictask.count') do
+      delete :destroy, params: { project_id: 'ecookbook', id: other.id }
+    end
+    assert_response 404
+    assert_equal 2, other.reload.project_id
+    assert_equal 'Onlinestore task', other.subject
+  end
+
+  def test_index_sorts_business_day_intervals_by_duration
+    create_test_periodictask(subject: 'One week', interval_number: 1, interval_units: 'week')
+    create_test_periodictask(subject: 'Three business days', interval_number: 3, interval_units: 'business_day')
+    create_test_periodictask(subject: 'One day', interval_number: 1, interval_units: 'day')
+    get :index, params: { project_id: 'ecookbook', sort: 'interval:asc' }
+    assert_response :success
+    body = @response.body
+    assert_operator body.index('One day'), :<, body.index('Three business days')
+    assert_operator body.index('Three business days'), :<, body.index('One week')
+  end
+
   def test_denies_member_without_permission
     # dlopez (user 3) is a Developer member of ecookbook but the Developer role
     # was not granted the :periodictask permission in setup.

--- a/test/functional/periodictask_controller_test.rb
+++ b/test/functional/periodictask_controller_test.rb
@@ -722,6 +722,21 @@ class PeriodictaskControllerTest < ActionController::TestCase
     assert_equal 'Onlinestore task', other.subject
   end
 
+  def test_index_marks_disabled_and_failed_tasks
+    create_test_periodictask(subject: 'Paused task', is_active: false)
+    create_test_periodictask(subject: 'Broken task', last_error: 'Tracker cannot be blank')
+    get :index, params: { project_id: 'ecookbook' }
+    assert_response :success
+    assert_select 'td', text: /Paused task/ do
+      assert_select 'span.icon-locked[title=?]', I18n.t(:label_disabled)
+      assert_select 'span.icon-locked svg' if Redmine::VERSION::MAJOR >= 6
+    end
+    assert_select 'td', text: /Broken task/ do
+      assert_select 'span.icon-error[title=?]', 'Tracker cannot be blank'
+      assert_select 'span.icon-error svg' if Redmine::VERSION::MAJOR >= 6
+    end
+  end
+
   def test_index_sorts_business_day_intervals_by_duration
     create_test_periodictask(subject: 'One week', interval_number: 1, interval_units: 'week')
     create_test_periodictask(subject: 'Three business days', interval_number: 3, interval_units: 'business_day')


### PR DESCRIPTION
## Summary

Consistency pass over the last 11 merged PRs (cron-less scheduling, admin list, copy, active flag, target version, shifted/offset macros...). Full suite (229 runs) and `rubocop` are green; locale key sets are in sync. Four real issues found and fixed here, plus small drift:

**1. Cross-project task access (security).** `Periodictask.accessible` only checks the permission *globally*, and every id-based action did `Periodictask.accessible.find(params[:id])` then `@periodictask.project = @project`. So a user with `:periodictask` in project A could `show`/`edit`/`copy`/`run_now`/`destroy` and even move (`update` sets `project_id = @project.id`) any task of project B via `/projects/a/periodictask/<id_from_b>`. Now:

```ruby
before_action :find_periodictask, only: %i[show edit update copy destroy run_now]

def find_periodictask
  @periodictask = @project.periodictasks.accessible.find(params[:id])
rescue ActiveRecord::RecordNotFound
  render_404
end
```
(`customfields` uses the same scoped relation for `params[:periodictask][:id]`.) Test covers all six actions with a task from `onlinestore` reached through `ecookbook`.

**2. Checker leaked its locale into the request** (from the *Run checker now* / check URL PR). `ScheduledTasksChecker` set `I18n.locale = ENV['LOCALE'] || default` and never restored it; when run inline from `PeriodictaskAdminController#run_checker`, the flash `l(:notice_periodictask_checker_run)` was then rendered in Redmine's default language, not the admin's. Wrapped the loop in `I18n.with_locale(...)`. The new test (admin with `language: 'es'`) fails on `main` and passes here.

**3. Admin list ignored the `Active` flag** — the admin page (#162) landed before the active flag (#161) and didn't get the `periodictask_disabled_icon` marker the project list has. Added + tested.

**4. Disabled / last-error markers were invisible on Redmine 6+/7** (found in browser testing). Both were legacy empty spans (`<span class="icon-only icon-locked"></span>`), which render 0×0 once Redmine moved to SVG sprite icons. They now go through `periodictask_marker_icon(sprite, css_class, title)` → `periodictask_sprite_icon('lock' | 'warning')` inside the span; on Redmine 5 the helper returns nothing and the CSS-class icon still applies. Tests assert the `svg` child on Redmine ≥ 6.

Minor drift:
- `interval` sort in the project list treated `business_day` as 1 day; now `1.4` so `3 business days` sorts between `1 day` and `1 week`.
- `Run now` link in the project list lacked the `icon-reload` class the other action links have.
- README: `zh-TW` missing from the `LOCALE` list, tags plugin missing from *Plugins supported*, admin page not mentioned. CHANGELOG entries under *Fixes*.

Browser test results (Redmine 7.0, Docker Compose) are in the PR comment below.

Link to Devin session: https://app.devin.ai/sessions/e7e3db04f70542cdba13d7311fb2e562
Open in Devin Desktop: https://app.devin.ai/desktop/session/e7e3db04f70542cdba13d7311fb2e562?variant=devin
Requested by: @jperelli