### PR TITLE
7.1.1: check_periodictasks explains when the plugin is not loaded (Debian plugins dir) — fixes #179

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v7.1.1 - 2026-09-11
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- `rake redmine:check_periodictasks` explains what to do instead of failing with `uninitialized constant ScheduledTasksChecker` when the plugin sits in `plugins/` but Redmine loads plugins from another directory (Debian packages: `/var/lib/redmine/<instance>/plugins`); README section on Debian installs ([#179](https://github.com/jperelli/Redmine-Periodic-Task/issues/179)) (@jperelli)
+
 ## v7.1.0 - 2026-09-06
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ Run these from your Redmine root. The paths below assume `/opt/redmine`, adjust 
 
 Then restart Redmine so it loads the plugin (see [Restarting Redmine](#restarting-redmine)).
 
+### Debian / Ubuntu `redmine` package
+
+The Debian `redmine` 6.x package (Redmine root `/usr/share/redmine`) loads plugins from `/var/lib/redmine/<instance>/plugins/` (the instance is `default` unless you set `REDMINE_INSTANCE`), **not** from `/usr/share/redmine/plugins/`. A plugin cloned into `/usr/share/redmine/plugins/` does not show up under *Administration → Plugins*, and its rake task fails with `uninitialized constant ScheduledTasksChecker`, because Redmine still picks up the rake tasks from there. Install into the instance directory instead:
+
+    cd /usr/share/redmine
+    git clone https://github.com/jperelli/Redmine-Periodic-Task.git /var/lib/redmine/default/plugins/periodictask
+    bundle install
+    bundle exec rake redmine:plugins:migrate NAME=periodictask RAILS_ENV=production
+
+Or keep the clone in `/usr/share/redmine/plugins/periodictask` and symlink it: `ln -s /usr/share/redmine/plugins/periodictask /var/lib/redmine/default/plugins/periodictask`. Then restart Redmine. See `/usr/share/doc/redmine/README.Debian` for the details of the Debian layout.
+
 ## Upgrade
 
     cd /opt/redmine/plugins/periodictask

--- a/init.rb
+++ b/init.rb
@@ -33,7 +33,7 @@ Redmine::Plugin.register :periodictask do
   author 'Julian Perelli'
   description 'Recurring issues: creates issues from per-project templates on a schedule ' \
               '(daily, business days, weekly, monthly, yearly)'
-  version '7.1.0'
+  version '7.1.1'
   url 'https://github.com/jperelli/Redmine-Periodic-Task/'
   author_url 'https://jperelli.com.ar/'
 

--- a/lib/tasks/periodictask.rake
+++ b/lib/tasks/periodictask.rake
@@ -9,6 +9,18 @@ Rails.configuration.active_job.queue_adapter = :inline if Rails.configuration.re
 
 namespace :redmine do
   task check_periodictasks: :environment do
+    # Redmine loads every plugins/*/lib/tasks/*.rake under Rails.root, but
+    # only registers the plugins found in its plugins directory, which can be
+    # elsewhere (Debian packages: /var/lib/redmine/<instance>/plugins).
+    unless Redmine::Plugin.installed?(:periodictask)
+      abort <<~MSG
+        The periodictask plugin is not loaded by this Redmine.
+        Its rake task was found under #{Rails.root.join('plugins')}, but Redmine loads plugins from
+        #{Redmine::PluginLoader.directory}. Move or symlink the plugin there and restart Redmine.
+        See https://github.com/jperelli/Redmine-Periodic-Task#installation
+      MSG
+    end
+
     ScheduledTasksChecker.checktasks!
   end
 end

--- a/test/unit/check_periodictasks_rake_test.rb
+++ b/test/unit/check_periodictasks_rake_test.rb
@@ -1,0 +1,34 @@
+require "#{File.dirname(__FILE__)}/../test_helper"
+require 'rake'
+
+class CheckPeriodictasksRakeTest < ActiveSupport::TestCase
+  RAKEFILE = File.expand_path('../../lib/tasks/periodictask.rake', __dir__)
+
+  def setup
+    @previous_application = Rake.application
+    Rake.application = Rake::Application.new
+    Rake::Task.define_task(:environment)
+    Rake.load_rakefile(RAKEFILE)
+  end
+
+  def teardown
+    Rake.application = @previous_application
+  end
+
+  def test_runs_the_checker
+    ScheduledTasksChecker.expects(:checktasks!).once
+    Rake::Task['redmine:check_periodictasks'].invoke
+  end
+
+  def test_aborts_with_an_explanation_when_the_plugin_is_not_loaded
+    Redmine::Plugin.stubs(:installed?).with(:periodictask).returns(false)
+    ScheduledTasksChecker.expects(:checktasks!).never
+
+    _out, err = capture_io do
+      assert_raises(SystemExit) { Rake::Task['redmine:check_periodictasks'].invoke }
+    end
+    assert_match(/periodictask plugin is not loaded/, err)
+    assert_match(Regexp.escape(Redmine::PluginLoader.directory.to_s), err)
+    assert_match(%r{Redmine-Periodic-Task#installation}, err)
+  end
+end

--- a/test/unit/check_periodictasks_rake_test.rb
+++ b/test/unit/check_periodictasks_rake_test.rb
@@ -29,6 +29,6 @@ class CheckPeriodictasksRakeTest < ActiveSupport::TestCase
     end
     assert_match(/periodictask plugin is not loaded/, err)
     assert_match(Regexp.escape(Redmine::PluginLoader.directory.to_s), err)
-    assert_match(%r{Redmine-Periodic-Task#installation}, err)
+    assert_match(/Redmine-Periodic-Task#installation/, err)
   end
 end


### PR DESCRIPTION
## Summary

Fixes #179 (`NameError: uninitialized constant ScheduledTasksChecker` from `rake redmine:check_periodictasks` on a Debian-packaged Redmine 6.0.5). Released as **v7.1.1** (`init.rb` version bump, CHANGELOG dated section); tag `v7.1.1` after merge.

**Root cause** (not a plugin bug, but a layout trap the plugin can explain): Redmine's `lib/tasks/redmine.rake` loads rake tasks with a hardcoded glob, `Dir[Rails.root/"plugins/*/lib/tasks/**/*.rake"]`, while `Redmine::PluginLoader` loads plugins (init.rb, Zeitwerk autoload of `lib/`) from `config.redmine_plugins_directory`. The Debian `redmine` 6.x package patches that directory to `/usr/share/redmine/instances/default/plugins` → `/var/lib/redmine/default/plugins` (multi-tenancy patch, `default` instance assumed). A clone in `/usr/share/redmine/plugins/periodictask` is therefore never loaded — no plugin in the admin page, no `ScheduledTasksChecker` — but its rake task is still registered and blows up on the first constant it touches.

Reproduced on the upstream image by setting `config.redmine_plugins_directory = 'instances/default/plugins'` in `config/additional_environment.rb`: identical trace. Normal layout, with or without `eager_load`, works fine on 6.1 and 7.0.

**Change**

```ruby
task check_periodictasks: :environment do
  unless Redmine::Plugin.installed?(:periodictask)
    abort <<~MSG
      The periodictask plugin is not loaded by this Redmine.
      Its rake task was found under #{Rails.root.join('plugins')}, but Redmine loads plugins from
      #{Redmine::PluginLoader.directory}. Move or symlink the plugin there and restart Redmine.
      See https://github.com/jperelli/Redmine-Periodic-Task#installation
    MSG
  end
  ScheduledTasksChecker.checktasks!
end
```

- README: new *Debian / Ubuntu `redmine` package* subsection under Installation (clone into `/var/lib/redmine/default/plugins/` or symlink from `/usr/share/redmine/plugins/`).
- CHANGELOG: `v7.1.1` / Fixes entry.
- `test/unit/check_periodictasks_rake_test.rb`: loads the rakefile into a fresh `Rake::Application`; asserts the checker runs when the plugin is installed and that the task aborts with the two directories in the message when `Redmine::Plugin.installed?(:periodictask)` is false.

Rubocop clean; full plugin suite (540 runs) green locally on the 6.1 image.

Link to Devin session: https://app.devin.ai/sessions/6601c25f35d34388897d7d149c8c4779
Open in Devin Desktop: https://app.devin.ai/desktop/session/6601c25f35d34388897d7d149c8c4779?variant=devin
Requested by: @jperelli